### PR TITLE
Implemented the "->" operator for _MMSafe_ptr.

### DIFF
--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -3829,6 +3829,10 @@ LValue CodeGenFunction::EmitMemberExpr(const MemberExpr *E) {
     // A second reason for always checking the BaseLV is that it is the same for
     // all the fields in the struct, so more of the checks should optimize away.
     EmitDynamicBoundsCheck(Addr, E->getBoundsExpr(), BCK_Normal, nullptr);
+
+    // Checked C
+    // Before dereferencing, do a _MMSafe_ptr validity check.
+    EmitDynamicStructIDCheck(BaseExpr);
   } else
     BaseLV = EmitCheckedLValue(BaseExpr, TCK_MemberAccess);
 


### PR DESCRIPTION
Added a dynamic check before each dereference of an _MMSafe_ptr
by the "->" operator. The checking procedure is the same as when
 dereferencing by the "*" operator.