### PR TITLE
Updated the dynamic ID checker to handle transparent struct object ID.

### DIFF
--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -2044,6 +2044,7 @@ public:
   bool isCheckedPointerNtArrayType() const;        // Checked C Nt_Array type.
   bool isCheckedPointerMMType() const;             // Checked C _MM_ptr type.
   bool isCheckedPointerMMArrayType() const;        // Checked C _MM_Array_ptr type.
+  bool isCheckedPointerMMSafeType() const;         // Checked C MM Safe ptr.
   bool isAnyPointerType() const;   // Any C pointer or ObjC object pointer
   bool isBlockPointerType() const;
   bool isVoidPointerType() const;
@@ -2698,6 +2699,10 @@ public:
 
   bool isNTChecked() const { return getKind() == CheckedPointerKind::NtArray; }
   bool isChecked() const { return getKind() != CheckedPointerKind::Unchecked; }
+  bool isMMSafeChecked() const {
+    return getKind() == CheckedPointerKind::MMPtr ||
+           getKind() == CheckedPointerKind::MMArray;
+  }
   bool isUnchecked() const { return getKind() == CheckedPointerKind::Unchecked; }
   bool isSugared() const { return false; }
   QualType desugar() const { return QualType(this, 0); }
@@ -6629,6 +6634,10 @@ inline bool Type::isCheckedPointerMMArrayType() const {
   if (const PointerType *T = getAs<PointerType>())
     return T->getKind() == CheckedPointerKind::MMArray;
   return false;
+}
+
+inline bool Type::isCheckedPointerMMSafeType() const {
+  return isCheckedPointerMMType() || isCheckedPointerMMArrayType();
 }
 
 inline bool Type::isAnyPointerType() const {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -9650,6 +9650,13 @@ bool ASTContext::isEqualIgnoringChecked(QualType T1, QualType T2) const {
 // specification.
 bool ASTContext::isNotAllowedForNoPrototypeFunction(QualType QT) const {
   if (const PointerType *PT = QT->getAs<PointerType>()) {
+    // Checked C & FIXME: Checked C does not allow the return typf of a
+    // no-prototype function to be a spatial memory safe pointer.
+    // Currently, for the sake of easy development, we allow MMSafe pointers
+    // to be returnd by a no-prototype function. Since the MMSafe pointer
+    // should also ensure spatial memory safety (Future Work), we should
+    // fix this later.
+    if (PT->isMMSafeChecked()) return false;
     if (PT->isChecked())
       return true;
     if (PT->isFunctionPointerType())


### PR DESCRIPTION
Currently this change only affects _MM_ptr; however we need merge it to the arrayptr branch as we will change the CGDYnamicCheck.cpp file to handle dynamic ID checking on _MM_array_ptr.