### PR TITLE
Renamed the source file of the HarmonizeType pass.

### DIFF
--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -33,7 +33,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/IR/Verifier.h"
-#include "llvm/IR/HarmonizeType.h"
+#include "llvm/IR/CheckedCHarmonizeType.h"
 #include "llvm/LTO/LTOBackend.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/SubtargetFeature.h"


### PR DESCRIPTION
Added prefix "CheckedC" to the name of relavent files. The changes
on the LLVM end is at:
https://github.com/jzhou76/checkedc-llvm/commit/1191128dc6acc0a8fb853f6c1ce2ce089f18b7a1