### PR TITLE
Miscellaneous updates.

### DIFF
--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9540,7 +9540,10 @@ def err_illegal_decl_mm_ptr_to_non_struct : Error<
   "only struct types are allowed">;
 
 def err_illegal_cast_to_mm_ptr : Error<
-  "'%0' cannot be cast to an MMSafe pointer %1">;
+  "%0 cannot be cast to an MMSafe pointer %1">;
+
+def err_illegal_cast_from_mm_ptr: Error<
+  "MMSafe pointer %0 cannot be cast to %1">;
 
 def err_checked_cplusplus : Error<
   "checked extension not supported for C++">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9534,9 +9534,13 @@ def err_illegal_decl_nt_array_ptr_of_nonscalar : Error<
   "'%0' declared as _Nt_array_ptr of type %1; "
   "only integer and pointer types are allowed">;
 
+// for MMSafe pointer
 def err_illegal_decl_mm_ptr_to_non_struct : Error<
   "'%0' declared as _MM_ptr to type %1; "
   "only struct types are allowed">;
+
+def err_illegal_cast_to_mm_ptr : Error<
+  "'%0' cannot be cast to an MMSafe pointer %1">;
 
 def err_checked_cplusplus : Error<
   "checked extension not supported for C++">;
@@ -9751,6 +9755,7 @@ def err_bounds_type_annotation_lost_checking : Error<
   def err_initializer_expected_for_ptr : Error<
     "automatic variable %0 with _Ptr type must have initializer">;
 
+// For MMSafe pointer
   def err_initializer_expected_for_mm_ptr : Error<
     "automatic variable %0 with _MM_ptr type must have initializer">;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1987,7 +1987,9 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
     break;
   case Type::Pointer:
     AS = getTargetAddressSpace(cast<PointerType>(T)->getPointeeType());
-    if (T->isCheckedPointerMMType() || T->isCheckedPointerMMArrayType()) {
+    if (T->isCheckedPointerMMSafeType()) {
+      // Checked C:  MMSafe pointers have different size and memory alignment
+      // than raw C pointers.
       Width = Target->getPointerWidth(AS, T);
       Align = Target->getPointerAlign(AS, T);
     } else {

--- a/lib/CodeGen/Address.h
+++ b/lib/CodeGen/Address.h
@@ -48,11 +48,11 @@ public:
       // dereference an llvm::StructType.
       if (pointer->getType()->isMMPointerTy()) {
         _isMMPtr = true;
-        rawPointerTy = pointer->getType()->getMMPtrInnerPtr();
+        rawPointerTy = pointer->getType()->getMMPtrInnerPtrTy();
         pointer->mutateType(rawPointerTy);
       } else if (pointer->getType()->isMMArrayPointerTy()) {
         _isMMArrayPtr = true;
-        rawPointerTy = pointer->getType()->getMMArrayPtrInnerPtr();
+        rawPointerTy = pointer->getType()->getMMArrayPtrInnerPtrTy();
         pointer->mutateType(rawPointerTy);
       } else {
         rawPointerTy = originalPointerTy;
@@ -88,7 +88,7 @@ public:
     llvm::Type *pointerTy = getPointer()->getType();
     if (pointerTy->isMMPointerTy()) {
       // Checked C: extract the inner pointer inside an _MM_ptr.
-      return pointerTy->getMMPtrInnerPtr();
+      return pointerTy->getMMPtrInnerPtrTy();
     }
 
     return llvm::cast<llvm::PointerType>(getPointer()->getType());

--- a/lib/CodeGen/CGCall.cpp
+++ b/lib/CodeGen/CGCall.cpp
@@ -4548,18 +4548,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
           // to "case TEK_Aggregate" above.
           if (V->getType()->isMMPointerTy() && RetIRTy->isMMPointerTy() &&
               V->getType() != RetIRTy) {
-              llvm::Value *genericPtr =
-                Builder.CreateExtractValue(V, 0, V->getName() + "_genericPtr");
-              llvm::Value *ID =
-                Builder.CreateExtractValue(V, 1, V->getName() + "_ID");
-              llvm::Value *concretePtr = Builder.CreateBitCast
-                (genericPtr, cast<llvm::StructType>(RetIRTy)->getElementType(0),
-                 V->getName() + "_concretePtr");
-              llvm::Value *insertPtr =
-                Builder.CreateInsertValue(llvm::UndefValue::get(RetIRTy),
-                                          concretePtr, 0,
-                                          V->getName() + "_concreteRetTmp");
-              V = Builder.CreateInsertValue(insertPtr, ID, 1,
+            V = Builder.CreateMMSafePtrCast(V, RetIRTy,
                                             V->getName() + "_concreteRet");
           }
 

--- a/lib/CodeGen/CGCall.cpp
+++ b/lib/CodeGen/CGCall.cpp
@@ -3878,7 +3878,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
       // Checked C
       // Handle the case when a _MM_array_ptr<T> is returned by a function.
       // In this case, there could be a type mismatch between the concrete
-      // type from the caller side and the generic type from the calee side.
+      // type from the caller side and the generic type from the callee side.
       // Here we mutate the type of the concrete _MM_array_ptr to be
       // the generic one as the callee's.
       //
@@ -4127,14 +4127,15 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
           llvm::Value *LI = Builder.CreateLoad(EltPtr);
           IRCallArgs[FirstIRArg + i] = LI;
 
-          if (STy->isMMPointerRep()) {
+          if (STy->isMMSafePointerRep()) {
             // Checked C
-            // LLVM flatterns the struct representation of _MM_ptr<T>.
-            // There would be a type mismatch between the pointer of
+            // LLVM flatterns the struct representation of an MMSafe pointer.
+            // When calling a function with generic MMSafe pointer parameters,
+            // there would be a type mismatch between the pointer of
             // the generic type (implemented as "i8*") and the concrete pointer
-            // type for _MM_ptr<T>. Here we coerce the concrete type to be
-            // the same as the generic type. Vice versa does not work because
-            // it breaks the prototype of the function.
+            // type. Here we coerce the concrete type to be the generic type.
+            // The other way around does not work because it breaks the
+            // prototype of the function.
             IRCallArgs[FirstIRArg + i]->mutateType(
                 IRFuncTy->getParamType(FirstIRArg + i));
           }

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -1710,18 +1710,6 @@ void CodeGenFunction::EmitStoreOfScalar(llvm::Value *Value, Address Addr,
                                         LValueBaseInfo BaseInfo,
                                         TBAAAccessInfo TBAAInfo,
                                         bool isInit, bool isNontemporal) {
-  // Checked C
-  // For a store instruction, resolve the type mismatch between a
-  // _MM_array_ptr to an array of a conrete type and a _MM_array_ptr to
-  // an array of generic type.
-  // There are three EmitStoreOfScalar(); this one is holds the real
-  // implementation and the other two call this one.
-  if (Value->getType()->isMMArrayPointerTy() &&
-      Ty->isCheckedPointerMMArrayType() &&
-      Value->getType() != Addr.getElementType()) {
-    Value->mutateType(Addr.getElementType());
-  }
-
   if (!CGM.getCodeGenOpts().PreserveVec3Type) {
     // Handle vectors differently to get better performance.
     if (Ty->isVectorType()) {

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -1710,6 +1710,18 @@ void CodeGenFunction::EmitStoreOfScalar(llvm::Value *Value, Address Addr,
                                         LValueBaseInfo BaseInfo,
                                         TBAAAccessInfo TBAAInfo,
                                         bool isInit, bool isNontemporal) {
+  // Checked C
+  // For a store instruction, resolve the type mismatch between a
+  // _MM_array_ptr to an array of a conrete type and a _MM_array_ptr to
+  // an array of generic type.
+  // There are three EmitStoreOfScalar(); this one is holds the real
+  // implementation and the other two call this one.
+  if (Value->getType()->isMMArrayPointerTy() &&
+      Ty->isCheckedPointerMMArrayType() &&
+      Value->getType() != Addr.getElementType()) {
+    Value->mutateType(Addr.getElementType());
+  }
+
   if (!CGM.getCodeGenOpts().PreserveVec3Type) {
     // Handle vectors differently to get better performance.
     if (Ty->isVectorType()) {

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -1756,8 +1756,8 @@ void CodeGenFunction::EmitStoreOfScalar(llvm::Value *Value, Address Addr,
 
   llvm::Type *pointeeTy =
     cast<llvm::PointerType>(Addr.getPointer()->getType())->getElementType();
-  if (pointeeTy->isMMPointerTy() && Value->getType() != pointeeTy) {
-    // Checked C: Assign an NULL to an _MM_ptr.
+  if (pointeeTy->isMMSafePointerTy() && Value->getType() != pointeeTy) {
+    // Checked C: Assign an NULL to an _MM_ptr or _MM_array_ptr.
     // Get the Address of the inner pointer.
     Addr = Builder.CreateStructGEP(Addr, 0, CharUnits::fromQuantity(0),
                                    Addr.getName() + "_innerPtr");

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -2645,7 +2645,7 @@ LValue CodeGenFunction::EmitUnaryOpLValue(const UnaryOperator *E) {
                            nullptr);
 
     // Checked C: Check for Struct ID matching.
-    EmitDynamicStructIDCheck(E->getSubExpr());
+    EmitDynamicIDCheck(E->getSubExpr());
 
     // We should not generate __weak write barrier on indirect reference
     // of a pointer to object; as in void foo (__weak id *param); *param = 0;
@@ -3556,6 +3556,9 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
   EmitDynamicBoundsCheck(Addr, E->getBoundsExpr(), E->getBoundsCheckKind(),
                          nullptr);
 
+  // Checked C: Dynamic ID Check on _MM_array_ptr.
+  EmitDynamicIDCheck(E->getLHS());
+
   if (getLangOpts().ObjC &&
       getLangOpts().getGC() != LangOptions::NonGC) {
     LV.setNonGC(!E->isOBJCGCCandidate(getContext()));
@@ -3853,7 +3856,7 @@ LValue CodeGenFunction::EmitMemberExpr(const MemberExpr *E) {
     // Checked C
     // Before dereferencing, do a _MM_ptr validity check.
     // TODO: add support for _MM_array_ptr.
-    EmitDynamicStructIDCheck(BaseExpr);
+    EmitDynamicIDCheck(BaseExpr);
   } else
     BaseLV = EmitCheckedLValue(BaseExpr, TCK_MemberAccess);
 

--- a/lib/CodeGen/CGExprConstant.cpp
+++ b/lib/CodeGen/CGExprConstant.cpp
@@ -1675,10 +1675,10 @@ llvm::Constant *ConstantLValueEmitter::tryEmit() {
   // non-zero null pointer and addrspace casts that aren't trivially
   // represented in LLVM IR.
   auto destTy = CGM.getTypes().ConvertTypeForMem(DestType);
-  if (destTy->isMMPointerTy()) {
+  if (destTy->isMMSafePointerTy()) {
     // Checked C
-    // The source code should be assining NULL to an array of _MM_ptr.
-    destTy = cast<llvm::StructType>(destTy)->getMMPtrInnerPtr();
+    // Handling assigning NULL to an array of _MM_ptr or _MM_array_ptr.
+    destTy = cast<llvm::StructType>(destTy)->getMMSafePtrInnerPtr();
   }
   assert(isa<llvm::IntegerType>(destTy) || isa<llvm::PointerType>(destTy));
 

--- a/lib/CodeGen/CGExprConstant.cpp
+++ b/lib/CodeGen/CGExprConstant.cpp
@@ -1678,7 +1678,7 @@ llvm::Constant *ConstantLValueEmitter::tryEmit() {
   if (destTy->isMMSafePointerTy()) {
     // Checked C
     // Handling assigning NULL to an array of _MM_ptr or _MM_array_ptr.
-    destTy = cast<llvm::StructType>(destTy)->getMMSafePtrInnerPtr();
+    destTy = cast<llvm::StructType>(destTy)->getMMSafePtrInnerPtrTy();
   }
   assert(isa<llvm::IntegerType>(destTy) || isa<llvm::PointerType>(destTy));
 

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -2045,7 +2045,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
         // Here we need extract the inner raw pointer. For example, for
         // "p == NULL', where p is {%struct.node*, i64}, the next few lines
         // of code would generate "%struct.node* null" for NULL.
-        DstTy = DstTy->getMMPtrInnerPtr();
+        DstTy = DstTy->getMMPtrInnerPtrTy();
       } else if (SrcTy->isMMSafePointerTy()) {
         // TODO: Casting between MMSafe pointers could be dangerous.
         // Earlier during compiling we should check to ensure the cast is safe.
@@ -2132,7 +2132,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     llvm::Type *llvmDestTy = ConvertType(DestTy);
     if (DestTy->isCheckedPointerMMSafeType()) {
       // Checked C: assign an NULL to a _MM_ptr or _MM_array_ptr.
-      return CGF.CGM.getNullPointer(llvmDestTy->getMMSafePtrInnerPtr(), DestTy);
+      return CGF.CGM.getNullPointer(llvmDestTy->getMMSafePtrInnerPtrTy(), DestTy);
     } else {
       return CGF.CGM.getNullPointer(cast<llvm::PointerType>(llvmDestTy), DestTy);
     }

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -2112,10 +2112,9 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     if (MustVisitNullValue(E))
       (void) Visit(E);
     llvm::Type *llvmDestTy = ConvertType(DestTy);
-    if (DestTy->isCheckedPointerMMType()) {
-      // Checked C: assign an NULL to a MM_ptr.
-      return CGF.CGM.getNullPointer(
-          cast<llvm::StructType>(llvmDestTy)->getMMPtrInnerPtr(), DestTy);
+    if (DestTy->isCheckedPointerMMSafeType()) {
+      // Checked C: assign an NULL to a _MM_ptr or _MM_array_ptr.
+      return CGF.CGM.getNullPointer(llvmDestTy->getMMSafePtrInnerPtr(), DestTy);
     } else {
       return CGF.CGM.getNullPointer(cast<llvm::PointerType>(llvmDestTy), DestTy);
     }

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -2044,9 +2044,6 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
       // Here we need extract the inner raw pointer. For example, for
       // "p == NULL', where p is {%struct.node*, i64}, the next few lines
       // of code would generate "%struct.node* null" for NULL.
-      //
-      // TODO: trying casting a raw pointer to an MMSafePtr should be
-      // caught as an error much early in compilation.
       DstTy = DstTy->getMMPtrInnerPtr();
     }
     return Builder.CreateBitCast(Src, DstTy);

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2938,7 +2938,7 @@ public:
                                   const BoundsExpr *CastBounds,
                                   const BoundsExpr *SubExprBounds);
   void EmitDynamicCheckBlocks(llvm::Value *Condition);
-  void EmitDynamicStructIDCheck(const Expr *E);
+  void EmitDynamicIDCheck(const Expr *E);
   llvm::BasicBlock *EmitDynamicCheckFailedBlock();
   llvm::BasicBlock *EmitNulltermWriteAdditionalCheck(const Address PtrAddr,
                                                      const Address Upper,

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2726,6 +2726,14 @@ void CastOperation::CheckCStyleCast(bool IsCheckedScope) {
     SrcExpr = ExprError();
     return;
   }
+  // Disallow cast an MMSafe pointer to a non-MMSafe pointer.
+  if (SrcType->isCheckedPointerMMSafeType() &&
+      !DestType->isCheckedPointerMMSafeType()) {
+    Self.Diag(SrcExpr.get()->getExprLoc(),
+        diag::err_illegal_cast_from_mm_ptr) << SrcType << DestType;
+    SrcExpr = ExprError();
+    return;
+  }
 
   DiagnoseCastOfObjCSEL(Self, SrcExpr, DestType);
   DiagnoseCallingConvCast(Self, SrcExpr, DestType, OpRange);

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2701,7 +2701,7 @@ void CastOperation::CheckCStyleCast(bool IsCheckedScope) {
       return;
     }
 
-    // Disallow cast from other Checked Pointer types to nt_arary_ptr because 
+    // Disallow cast from other Checked Pointer types to nt_arary_ptr because
     // the SrcType might not point to a NULL-terminated array.
     if (DestType->isPointerType() && DestType->isCheckedPointerNtArrayType()) {
         if (SrcType->isPointerType() && !SrcType->isCheckedPointerNtArrayType()) {
@@ -2713,6 +2713,18 @@ void CastOperation::CheckCStyleCast(bool IsCheckedScope) {
         }
     }
 
+  }
+
+  // Checked C
+  // Disallow cast a non-MMSafe pointer type to an MMSafe pointer type.
+  // JZ: What does "SrcExpr.get()->getSourceRange();" do at line 2710? The
+  // error message looks the same without this getSourceRange().
+  if (DestType->isCheckedPointerMMSafeType() &&
+      !SrcType->isCheckedPointerMMSafeType()) {
+    Self.Diag(SrcExpr.get()->getExprLoc(),
+        diag::err_illegal_cast_to_mm_ptr) << SrcType << DestType;
+    SrcExpr = ExprError();
+    return;
   }
 
   DiagnoseCastOfObjCSEL(Self, SrcExpr, DestType);

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -8022,6 +8022,16 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, QualType RHSType) {
     }
   }
 
+  // Checked C
+  // Check if this is assigning an unchecked pointer to an MMSafe pointer.
+  // We can do the checking earlier in the call stack, such as in
+  // Sema::CheckAssignmentOperands; however, it is cleaner to do it here.
+  if (rhkind == CheckedPointerKind::Unchecked &&
+      (lhkind == CheckedPointerKind::MMPtr ||
+       lhkind == CheckedPointerKind::MMArray)) {
+    return Sema::Incompatible;
+  }
+
   // Handle Checked C cases (where one pointer is checked).
   if (lhkind != CheckedPointerKind::Unchecked ||
       rhkind != CheckedPointerKind::Unchecked) {


### PR DESCRIPTION
When the `safe-mm-arrayptr` was created I intended to develop the _MM_array_ptr<T>. However, during development I encountered many issues related to _MM_ptr<T> or any type of MMSafe pointers. To summarize, this merge has the following upates:
- added basic support for _MM_array_ptr<T>, including basic definition, assignment, and dereference.
- revised the code that mutates generic pointer type to concrete pointer type; instead we use cast to change the type.
- fixed bugs in the dynamic ID checking function.
- added basic support to handle cast and assignment between raw/mmsafe pointers and mmsafe pointers.

See the commits for details.

Note that the `_MM_array_ptr<T>` has not been finished.

