### PR TITLE
Implement pointer arithmetic for mm_array_ptr.

### DIFF
--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -661,15 +661,17 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
                            addEfficiencySanitizerPass);
   }
 
+  // Checked C
+  // Run the MMSafePtr type mismatch resolving pass.  Run this pass before
+  // the VerifierPass, otherwise the VerifierPass would fail.
+  if (CodeGenOpts.HarmonizeType) {
+    FPM.add(createHarmonizeTypePass());
+  }
+
   // Set up the per-function pass manager.
   FPM.add(new TargetLibraryInfoWrapperPass(*TLII));
   if (CodeGenOpts.VerifyModule)
     FPM.add(createVerifierPass());
-
-  /// Checked C: run the _MM_ptr type mismatch resolving pass.
-  if (CodeGenOpts.HarmonizeType) {
-    FPM.add(createHarmonizeTypePass());
-  }
 
   // Set up the per-module pass manager.
   if (!CodeGenOpts.RewriteMapFiles.empty())

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -3283,6 +3283,89 @@ static Value *emitPointerArithmetic(CodeGenFunction &CGF,
                                     op.E->getExprLoc(), "add.ptr");
 }
 
+//
+// Checked C
+// Emit pointer addition for _MM_array_ptr.
+//
+// This function extracts the inner raw pointer of the MMArrayPtr and
+// does a normal pointer addition, and creates a new MMArrayPtr with the
+// result of the addition and the ID and the object ID address from the
+// source MMArrayPtr.
+//
+static Value *emitMMArrayPointerAdd(CodeGenFunction &CGF, const BinOpInfo &op) {
+  CGBuilderTy &Builder = CGF.Builder;
+  Value *LHS = op.LHS, *RHS = op.RHS;
+  Value *Ptr = LHS->getType()->isMMArrayPointerTy() ? LHS : RHS;
+  Value *Num = LHS->getType()->isMMArrayPointerTy() ? RHS : LHS;
+  Value *rawPtr = Builder.CreateExtractValue(Ptr, 0,
+                                             Ptr->getName() + "_innerPtr");
+
+  // Create a new BinOpInfo and does a normal pointer arithmetic.
+  BinOpInfo rawPtrArithmeticOp = op;
+  rawPtrArithmeticOp.LHS = rawPtr;
+  rawPtrArithmeticOp.RHS = Num;
+  Value *Add = emitPointerArithmetic(CGF, rawPtrArithmeticOp, false);
+
+  // Extract the ID and the Addr of the ID from the Src MMArrayPtr.
+  Value *ID = Builder.CreateExtractValue(Ptr, 1);
+  Value *ObjIDPtr = Builder.CreateExtractValue(Ptr, 2);
+  // Create and return a new MMSafePtr.
+  llvm::UndefValue *Dest = llvm::UndefValue::get(Ptr->getType());
+  Value *insertNewPtr = Builder.CreateInsertValue(Dest, Add, 0);
+  Value *insertID = Builder.CreateInsertValue(insertNewPtr, ID, 1);
+  return Builder.CreateInsertValue(insertID, ObjIDPtr, 2);
+}
+
+//
+// Checked C
+// Emit pointer subtraction for _MM_array_ptr.
+//
+// For MMArrayPtr subtracting a number, this function extracts the inner
+// raw pointer and does a normal pointer subtraction, and creates a new
+// MMSafePtr with the result of the subtraction and the ID and the object ID
+// address from the source MMSafePtr.
+// For pointer subtraction between two MMArrayPtr, this function extracts
+// the raw pointers of both sides, does a normal pointer subtraction and
+// return the result.
+//
+// @param SEE - used to call ScalarExprEmitter::EmitSub() in case of this is
+//              subtraction between two MMArrayPtr.
+//
+static Value *emitMMArrayPointerSub(ScalarExprEmitter &SEE,
+                                    CodeGenFunction &CGF, const BinOpInfo &op) {
+  CGBuilderTy &Builder = CGF.Builder;
+  Value *LHS = op.LHS, *RHS = op.RHS;
+
+  BinOpInfo rawPtrArithmeticOp = op;
+  Value *rawLHS = Builder.CreateExtractValue(LHS, 0,
+                                             LHS->getName() + "_innerPtr");
+  Value *rawRHS = RHS;
+  if(RHS->getType()->isMMArrayPointerTy()) {
+    rawRHS = Builder.CreateExtractValue(RHS, 0,
+                                       RHS->getName() + "_innerPtr");
+    // If this is a subtraction between pointers, we need check if
+    // they are pointing to the same array.
+    // TO-DO: do the checking mentioned above.
+
+    rawPtrArithmeticOp.LHS = rawLHS;
+    rawPtrArithmeticOp.RHS = rawRHS;
+    return SEE.EmitSub(rawPtrArithmeticOp);
+  }
+
+  rawPtrArithmeticOp.LHS = rawLHS;
+  rawPtrArithmeticOp.RHS = rawRHS;
+  Value *Sub = emitPointerArithmetic(CGF, rawPtrArithmeticOp, true);
+
+  // Extract the ID and the Addr of the ID from the Src MMArrayPtr.
+  Value *ID = Builder.CreateExtractValue(LHS, 1);
+  Value *ObjIDPtr = Builder.CreateExtractValue(LHS, 2);
+  // Create a new MMSafePtr.
+  llvm::UndefValue *Dest = llvm::UndefValue::get(LHS->getType());
+  Value *insertNewPtr = Builder.CreateInsertValue(Dest, Sub, 0);
+  Value *insertID = Builder.CreateInsertValue(insertNewPtr, ID, 1);
+  return Builder.CreateInsertValue(insertID, ObjIDPtr, 2);
+}
+
 // Construct an fmuladd intrinsic to represent a fused mul-add of MulOp and
 // Addend. Use negMul and negAdd to negate the first operand of the Mul or
 // the add operand respectively. This allows fmuladd to represent a*b-c, or
@@ -3355,6 +3438,13 @@ Value *ScalarExprEmitter::EmitAdd(const BinOpInfo &op) {
       op.RHS->getType()->isPointerTy())
     return emitPointerArithmetic(CGF, op, CodeGenFunction::NotSubtraction);
 
+  // Checked C
+  // Emit an MMArrayPtr add.
+  if (op.LHS->getType()->isMMArrayPointerTy() ||
+      op.RHS->getType()->isMMArrayPointerTy()) {
+    return emitMMArrayPointerAdd(CGF, op);
+  }
+
   if (op.Ty->isSignedIntegerOrEnumerationType()) {
     switch (CGF.getLangOpts().getSignedOverflowBehavior()) {
     case LangOptions::SOB_Defined:
@@ -3388,6 +3478,12 @@ Value *ScalarExprEmitter::EmitAdd(const BinOpInfo &op) {
 }
 
 Value *ScalarExprEmitter::EmitSub(const BinOpInfo &op) {
+  // Checked C
+  // Emit an MMArrayPtr sub.
+  if (op.LHS->getType()->isMMArrayPointerTy()) {
+    return emitMMArrayPointerSub(*this, CGF, op);
+  }
+
   // The LHS is always a pointer if either side is.
   if (!op.LHS->getType()->isPointerTy()) {
     if (op.Ty->isSignedIntegerOrEnumerationType()) {

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -3343,10 +3343,14 @@ static Value *emitMMArrayPointerSub(ScalarExprEmitter &SEE,
   if(RHS->getType()->isMMArrayPointerTy()) {
     rawRHS = Builder.CreateExtractValue(RHS, 0,
                                        RHS->getName() + "_innerPtr");
-    // If this is a subtraction between pointers, we need check if
-    // they are pointing to the same array.
-    // TO-DO: do the checking mentioned above.
+    // Check if the LHS and RHS are pointing to the same array;
+    // we disallow subtraction between MMArrayPtr to different arrays.
+    Value *IDLHS = Builder.CreateExtractValue(LHS, 1);
+    Value *IDRHS = Builder.CreateExtractValue(RHS, 1);
+    CGF.EmitDynamicCheckBlocks(Builder.CreateICmpEQ(IDLHS, IDRHS,
+                               "MMArrayPtrSubIDCheck"));
 
+    // ID checking passes. Emit a normal subtraction between two pointers.
     rawPtrArithmeticOp.LHS = rawLHS;
     rawPtrArithmeticOp.RHS = rawRHS;
     return SEE.EmitSub(rawPtrArithmeticOp);


### PR DESCRIPTION
Implemented pointer arithmetic for `mm_array_ptr`, including
- `p +/- var/const`
- `p++/--` and `++/--p`
- `*p++/--` and `*++/--p`

The corresponding change on the LLVM side is that we updated the `HarmonizeTypePass` to fix ill-formed instructions from
the third type of operations listed above. The commits are
https://github.com/jzhou76/checkedc-llvm/commit/d83f3da5df6fbebe55eade71a0f2f527b7bccfd3 and
https://github.com/jzhou76/checkedc-llvm/commit/8bcbcba02607f4cb9b2656f6197c5ec1e5b84316