### PR TITLE
Implemented '&' operator on an inner object of an object pointed by an MMSafe pointer.

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -2045,6 +2045,15 @@ public:
   }
   bool isArithmeticOp() const { return isArithmeticOp(getOpcode()); }
 
+  /// Checked C
+  /// Check if this is an address-of (&) operator.
+  /// The method isPrefix() is a little misleading as it only checks if
+  /// this is a prefix increment/decrement operation. The address-of operator
+  /// "&" is also a prefix operator.
+  bool isAddressOf() const {
+    return getOpcode() == UO_AddrOf;
+  }
+
   /// getOpcodeStr - Turn an Opcode enum value into the punctuation char it
   /// corresponds to, e.g. "sizeof" or "[pre]++"
   static StringRef getOpcodeStr(Opcode Op);

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -1744,9 +1744,10 @@ void CodeGenFunction::EmitStoreOfScalar(llvm::Value *Value, Address Addr,
 
   llvm::Type *pointeeTy =
     cast<llvm::PointerType>(Addr.getPointer()->getType())->getElementType();
-  if (pointeeTy->isMMSafePointerTy() && Value->getType() != pointeeTy) {
-    // Checked C: Assign an NULL to an _MM_ptr or _MM_array_ptr.
-    // Get the Address of the inner pointer.
+  if (pointeeTy->isMMSafePointerTy() && isa<llvm::ConstantPointerNull>(Value)) {
+    // Checked C
+    // Assign a NULL to an _MM_ptr or _MM_array_ptr.
+    // Create a GEP to get the inner raw pointer and make it an Address.
     Addr = Builder.CreateStructGEP(Addr, 0, CharUnits::fromQuantity(0),
                                    Addr.getName() + "_innerPtr");
   }

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -7943,8 +7943,16 @@ ExprResult Sema::ActOnConditionalOp(SourceLocation QuestionLoc,
 // routine is it effectively iqnores the qualifiers on the top level pointee.
 // This circumvents the usual type rules specified in 6.2.7p1 & 6.7.5.[1-3].
 // FIXME: add a couple examples in this comment.
+//
+// Checked C
+// In order to know if the RHS is constructed by using the '&' operator
+// to get the address of a memory object, we modifed the prototype of
+// this function to take an ExprResult for the RHS instead of a QualType.
 static Sema::AssignConvertType
-checkPointerTypesForAssignment(Sema &S, QualType LHSType, QualType RHSType) {
+checkPointerTypesForAssignment(Sema &S, QualType LHSType, ExprResult &RHS) {
+  QualType RHSType = RHS.get()->getType();
+  RHSType = S.getASTContext().getCanonicalType(RHSType).getUnqualifiedType();
+
   assert(LHSType.isCanonical() && "LHS not canonicalized!");
   assert(RHSType.isCanonical() && "RHS not canonicalized!");
 
@@ -8024,11 +8032,69 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, QualType RHSType) {
 
   // Checked C
   // Check if this is assigning an unchecked pointer to an MMSafe pointer.
-  // We can do the checking earlier in the call stack, such as in
-  // Sema::CheckAssignmentOperands; however, it is cleaner to do it here.
+  // We disallow assigning a raw C pointer to an MMSafe pointer unless
+  // this pointer is constructed by getting the address of a memory object
+  // pointed by an MMSafe pointer. We also do not allow assigning the pointer
+  // of one type to an MMSafe pointer of another type.
+  //
+  // Another implementation choice is to do the check earlier in
+  // Sema::CheckSingleAssignmentConstraints(). In that case we do not need
+  // to modify the prototype of this function because the ExprResult of the
+  // RHS is available there.
   if (rhkind == CheckedPointerKind::Unchecked &&
       (lhkind == CheckedPointerKind::MMPtr ||
        lhkind == CheckedPointerKind::MMArray)) {
+    UnaryOperator *UO = dyn_cast<UnaryOperator>(RHS.get());
+    if (UO && UO->isAddressOf()) {
+      Expr *E = UO->getSubExpr();
+#if 0
+      // Do we want to check if the type of the pointee of the LHS matches the
+      // type of the memory object whose address is taken? Disallowing it
+      // may break some OOP style C code.
+      if (E->getType()->getUnqualifiedDesugaredType() !=
+          lhptee->getUnqualifiedDesugaredType()) {
+        return Sema::Incompatible;
+      }
+#endif
+
+      // Traverse the RHS from right to left to see if the '&' operator is
+      // applied on a inner filed of a memory object pointed by an MMSafePtr.
+      while (true) {
+        // Strip off cast and parentheses
+        while (isa<CastExpr>(E) || isa<ParenExpr>(E)) {
+          E = isa<CastExpr>(E) ? cast<CastExpr>(E)->getSubExpr() :
+                                 cast<ParenExpr>(E)->getSubExpr();
+        }
+
+        if (isa<MemberExpr>(E)) {
+          Expr *base = cast<MemberExpr>(E)->getBase();
+          if (base->getType()->isCheckedPointerMMSafeType()) {
+            return Sema::Compatible;
+          } else {
+            // Keep looking.
+            E = base;
+          }
+        } else if (isa<ArraySubscriptExpr>(E)) {
+          // Keep looking
+          E = cast<ArraySubscriptExpr>(E)->getBase();
+        } else if (isa<UnaryOperator>(E)) {
+          // In case there is a "*" operator.
+          E = cast<UnaryOperator>(E)->getSubExpr();
+        } else if (isa<DeclRefExpr>(E)) {
+          // Has reached the leftmost part of the RHS.
+          if (E->getType()->isCheckedPointerMMSafeType()) {
+            return Sema::Compatible;
+          } else {
+            return Sema::Incompatible;
+          }
+        } else {
+          // A fail-safe assertion for debugging.
+          assert(0 &&
+              "Unknown Expr in parsing the RHS for pointer assignment check.");
+        }
+      }
+    }
+
     return Sema::Incompatible;
   }
 
@@ -8402,7 +8468,7 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
         Kind = CK_NoOp;
       else
         Kind = CK_BitCast;
-      return checkPointerTypesForAssignment(*this, LHSType, RHSType);
+      return checkPointerTypesForAssignment(*this, LHSType, RHS);
     }
 
     // int -> T*

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -2018,6 +2018,7 @@ QualType Sema::BuildPointerType(QualType T, CheckedPointerKind kind,
     return QualType();
   }
 
+#if 0
   // Checked C: _MM_ptr is only allowed to point to struct types.
   // One special case is when a _MM_ptr is in a generic function, the
   // type of its pointee is allowed to be a TypeVariableType.
@@ -2027,6 +2028,7 @@ QualType Sema::BuildPointerType(QualType T, CheckedPointerKind kind,
       << getPrintableNameForEntity(Entity) << T;
     return QualType();
   }
+#endif
 
   // Build the pointer type.
   return Context.getPointerType(T, kind);


### PR DESCRIPTION
When the address-of operator '&' is applied on an inner memory object inside an object that is pointed by an MMSafe pointer,
the result should also be an MMSafe pointer which shares the same key with some offset.

- Implemented '&' on an inner object of a struct pointed by an MMSafe pointer.
- Updated the dynamic key-lock checking code to handle the new key-offset design (32-32 key-offset).

Currently we haven't written code to compute the offset of an item in array because we plan to change the design of the `mm_array_ptr` to the same structure as `mm_ptr` because a 32-32 key-offset scheme should be good enough to deal with most array pointers. We can add a third type of pointer to deal with extremely large arrays that are greater than `4GB`.