### PR TITLE
[mm_array_ptr] Implemented the 2-field mm_array_ptr.

### DIFF
--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -198,10 +198,10 @@ public:
     CheckedC_None,
 
     // For stack & global objects to which pointers might point to heap.
-    Multiple,
+    Checkable,
 
     // For objects shared between checked and unchecked code
-    Shared
+    Shared,
   };
 
   /// Returns the common set of qualifiers while removing them from
@@ -311,9 +311,9 @@ public:
     Mask |= mask;
   }
   // Checked C
-  void addCVRUMQualifiers(unsigned mask) {
-    assert(!(mask & ~CVRMask & ~UMask & ~MultipleMask) &&
-          "bit mask contains non-CVRUM bits");
+  void addCVRUCQualifiers(unsigned mask) {
+    assert(!(mask & ~CVRMask & ~UMask & ~CheckableMask) &&
+          "bit mask contains non-CVRUC bits");
     Mask |= mask;
   }
 
@@ -325,11 +325,11 @@ public:
   void addUnaligned() { Mask |= UMask; }
 
   // Checked C
-  bool hasMultiple() const { return Mask & MultipleMask; }
-  void setMultiple(bool flag) {
-    Mask = (Mask & ~MultipleMask) | (flag ? MultipleMask : 0);
+  bool hasCheckable() const { return Mask & CheckableMask; }
+  void setCheckable(bool flag) {
+    Mask = (Mask & ~CheckableMask) | (flag ? CheckableMask : 0);
   }
-  void addMultiple() { Mask |= CheckedCQual::Multiple; }
+  void addCheckable() { Mask |= CheckedCQual::Checkable; }
 
   bool hasObjCGCAttr() const { return Mask & GCAttrMask; }
   GC getObjCGCAttr() const { return GC((Mask & GCAttrMask) >> GCAttrShift); }
@@ -594,7 +594,7 @@ private:
   // Updated for Checked C:
   // bits:     |0 1 2|3|4 .. 5|6  ..  8|9  .. 10|11   ...   31|
   //           |C R V|U|GCAttr|Lifetime|CheckedC|AddressSpace|
-  // Currently bit 9 is for _multiple. bit 10 is reserved for the qualifer
+  // Currently bit 9 is for _checkable. bit 10 is reserved for the qualifer
   // that indicates a variable/field shared between checked and unchecked code.
   uint32_t Mask = 0;
 
@@ -605,8 +605,8 @@ private:
   static const uint32_t LifetimeMask = 0x1C0;
   static const uint32_t LifetimeShift = 6;
   static const uint32_t CheckedCMask = 0x600;
-  static const uint32_t MultipleMask = 0x200;
-  static const uint32_t MultipleShift = 9;
+  static const uint32_t CheckableMask = 0x200;
+  static const uint32_t CheckableShift = 9;
   static const uint32_t AddressSpaceMask =
       ~(CVRMask | UMask | GCAttrMask | LifetimeMask | CheckedCMask);
   static const uint32_t AddressSpaceShift = 11;
@@ -774,8 +774,8 @@ public:
   /// Determine whether this type is volatile-qualified.
   bool isVolatileQualified() const;
 
-  /// Checked C: Determine whether this type is _multiple-qualified.
-  bool isMultipleQualified() const;
+  /// Checked C: Determine whether this type is _checkable-qualified.
+  bool isCheckableQualified() const;
 
   /// Determine whether this particular QualType instance has any
   /// qualifiers, without looking through any typedefs that might add
@@ -2085,7 +2085,7 @@ public:
   bool isCheckedPointerNtArrayType() const;        // Checked C Nt_Array type.
   bool isCheckedPointerMMType() const;             // Checked C _MM_ptr type.
   bool isCheckedPointerMMArrayType() const;        // Checked C _MM_Array_ptr type.
-  bool isCheckedPointerMMSafeType() const;         // Checked C MM Safe ptr.
+  bool isCheckedPointerMMSafeType() const;         // Checked C MMSafe ptr.
   bool isAnyPointerType() const;   // Any C pointer or ObjC object pointer
   bool isBlockPointerType() const;
   bool isVoidPointerType() const;
@@ -6464,8 +6464,8 @@ inline bool QualType::isVolatileQualified() const {
 }
 
 /// Checked C
-inline bool QualType::isMultipleQualified() const {
-  return getCommonPtr()->CanonicalType.getLocalQualifiers().hasMultiple();
+inline bool QualType::isCheckableQualified() const {
+  return getCommonPtr()->CanonicalType.getLocalQualifiers().hasCheckable();
 }
 
 inline bool QualType::hasQualifiers() const {

--- a/include/clang/Basic/CodeGenOptions.def
+++ b/include/clang/Basic/CodeGenOptions.def
@@ -364,8 +364,8 @@ CODEGENOPT(BranchTargetEnforcement, 1, 0)
 /// Whether to emit unused static constants.
 CODEGENOPT(KeepStaticConsts, 1, 0)
 
-/// Checked C: Create a lock for _multiple stack & global objects.
-CODEGENOPT(CheckedCAddLockToMultiple, 1, 1)
+/// Checked C: Create a lock for _checkable stack & global objects.
+CODEGENOPT(CheckedCAddLockToCheckable, 1, 1)
 /// Checked C: Resolve the _MMPtr and _MM_array_ptr type mismatch issue.
 CODEGENOPT(CheckedCHarmonizeType, 1, 1)
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9535,10 +9535,6 @@ def err_illegal_decl_nt_array_ptr_of_nonscalar : Error<
   "only integer and pointer types are allowed">;
 
 // for MMSafe pointer
-def err_illegal_decl_mm_ptr_to_non_struct : Error<
-  "'%0' declared as _MM_ptr to type %1; "
-  "only struct types are allowed">;
-
 def err_illegal_cast_to_mm_ptr : Error<
   "%0 cannot be cast to an MMSafe pointer %1">;
 

--- a/include/clang/Basic/TargetInfo.h
+++ b/include/clang/Basic/TargetInfo.h
@@ -20,7 +20,6 @@
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetCXXABI.h"
 #include "clang/Basic/TargetOptions.h"
-#include "clang/AST/Type.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/Optional.h"
@@ -346,30 +345,22 @@ public:
 
   /// Return the width of pointers on this target, for the
   /// specified address space.
-  uint64_t getPointerWidth(unsigned AddrSpace) const {
-    return AddrSpace == 0 ? PointerWidth : getPointerWidthV(AddrSpace);
-  }
-  uint64_t getPointerAlign(unsigned AddrSpace) const {
-    return AddrSpace == 0 ? PointerAlign : getPointerAlignV(AddrSpace);
-  }
+  //
   /// Checked C
-  /// MM pointers are fat pointers; so their lengths are greater than
-  /// PointerWdith and their alignments are greater than PointerAlign.
+  /// MMSafe pointers are fat pointers; so their lengths are greater than
+  /// PointerWidth and their alignments are greater than PointerAlign.
   ///
-  /// FIXME: Currently we only implement for the x86-64 architecture;
-  /// so we fix the width and alginment of MM pointers to 16 bytes
-  /// and 16 bytes for struct, and 24 bytes and 32 bytes for arrays.
+  /// TODO: Currently we only implement for the x86-64 architecture;
+  /// so the width and alginment of MM pointers are 16 bytes.
   /// Later if we want to support more architectures we need change
   /// this function.
-  ///
-  uint64_t getPointerWidth(unsigned AddrSpace, const clang::Type *T) const {
-    /// The magic number 64 means the lenght of the key of a MMSafe pointer.
-    return T->isCheckedPointerMMType() ? PointerWidth + 64 :
-                                         PointerWidth * 2 + 64;
+  uint64_t getPointerWidth(unsigned AddrSpace, bool isMMSafePtr=false) const {
+    return AddrSpace == 0 ? (isMMSafePtr ? PointerWidth + 64 : PointerWidth) :
+                            getPointerWidthV(AddrSpace);
   }
-  uint64_t getPointerAlign(unsigned AddrSpace, const clang::Type *T) const {
-    return T->isCheckedPointerMMType() ? PointerAlign * 2 :
-                                         PointerAlign * 4;
+  uint64_t getPointerAlign(unsigned AddrSpace, bool isMMSafePtr=false) const {
+    return AddrSpace == 0 ? (isMMSafePtr ? PointerAlign * 2 : PointerAlign) :
+                            getPointerAlignV(AddrSpace);
   }
 
   /// Return the maximum width of pointers on this target.

--- a/include/clang/Basic/TokenKinds.def
+++ b/include/clang/Basic/TokenKinds.def
@@ -670,7 +670,7 @@ KEYWORD(_Itype_for_any             , KEYCHECKEDC)
 KEYWORD(_Current_expr_value        , KEYCHECKEDC)
 KEYWORD(_Return_value              , KEYCHECKEDC)
 KEYWORD(_Bounds_only               , KEYCHECKEDC)
-KEYWORD(_multiple                  , KEYCHECKEDC)
+KEYWORD(_checkable                 , KEYCHECKEDC)
 
 // Borland Extensions which should be disabled in strict conformance mode.
 ALIAS("_pascal"      , __pascal   , KEYBORLAND)

--- a/include/clang/Sema/DeclSpec.h
+++ b/include/clang/Sema/DeclSpec.h
@@ -325,7 +325,7 @@ public:
     // as a qualifier in our type system.
     TQ_atomic      = 16,
     // Checked C
-    TQ_multiple    = 32,
+    TQ_checkable   = 32,
   };
 
   /// ParsedSpecifiers - Flags to query which specifiers were applied.  This is
@@ -365,7 +365,7 @@ private:
   unsigned TypeSpecSat : 1;
 
   // type-qualifiers
-  // Checked C: updated TypeQualifiers from 5 to 6 for the _multiple qualifier.
+  // Checked C: updated TypeQualifiers from 5 to 6 for the _checkable qualifier.
   unsigned TypeQualifiers : 6;  // Bitwise OR of TQ.
 
   // function-specifier
@@ -419,7 +419,7 @@ private:
   SourceLocation TSTNameLoc;
   SourceRange TypeofParensRange;
   SourceLocation TQ_constLoc, TQ_restrictLoc, TQ_volatileLoc, TQ_atomicLoc,
-      TQ_unalignedLoc, TQ_multipleLoc;  // Added TQ_multipleLoc
+      TQ_unalignedLoc, TQ_checkableLoc;  // Added TQ_checkableLoc
   SourceLocation FS_inlineLoc, FS_virtualLoc, FS_explicitLoc, FS_noreturnLoc;
   SourceLocation FS_forceinlineLoc;
   // Checked C - checked keyword location
@@ -592,7 +592,7 @@ public:
   SourceLocation getUnalignedSpecLoc() const { return TQ_unalignedLoc; }
   SourceLocation getPipeLoc() const { return TQ_pipeLoc; }
   // Checked C
-  SourceLocation getMultipleSpecLoc() const { return TQ_multipleLoc; }
+  SourceLocation getCheckableSpecLoc() const { return TQ_checkableLoc; }
 
   /// Clear out all of the type qualifiers.
   void ClearTypeQualifiers() {
@@ -604,7 +604,7 @@ public:
     TQ_unalignedLoc = SourceLocation();
     TQ_pipeLoc = SourceLocation();
     // Checked C
-    TQ_multipleLoc = SourceLocation();
+    TQ_checkableLoc = SourceLocation();
   }
 
   // function-specifier
@@ -667,12 +667,12 @@ public:
     FS_itypeforanyloc= SourceLocation();
   }
 
-  /// This method calls the passed in handler on each CVRUM qual being
+  /// This method calls the passed in handler on each CVRUC qual being
   /// set.
   /// Handle - a handler to be invoked.
   ///
-  /// Checked C: added "M" to "CVRU".
-  void forEachCVRUMQualifier(
+  /// Checked C: added "C" to "CVRU".
+  void forEachCVRUCQualifier(
       llvm::function_ref<void(TQ, StringRef, SourceLocation)> Handle);
 
   /// This method calls the passed in handler on each qual being
@@ -1248,7 +1248,7 @@ struct DeclaratorChunk {
 
   struct PointerTypeInfo {
     /// The type qualifiers: const/volatile/restrict/unaligned/atomic.
-    // Checked C: plus multiple
+    // Checked C: plus _checkable
     unsigned TypeQuals : 6;
 
     /// The location of the const-qualifier, if any.
@@ -1266,7 +1266,7 @@ struct DeclaratorChunk {
     /// The location of the __unaligned-qualifier, if any.
     unsigned UnalignedQualLoc;
 
-    /// Checked C: The location of the _multiple-qualifier, if any.
+    /// Checked C: The location of the _checkabler-qualifier, if any.
     unsigned MMSafeQualLoc;
 
     void destroy() {
@@ -1285,7 +1285,7 @@ struct DeclaratorChunk {
   struct ArrayTypeInfo {
     /// The type qualifiers for the array:
     /// const/volatile/restrict/__unaligned/_Atomic.
-    // Checked C: plus _multiple
+    // Checked C: plus _checkable
     unsigned TypeQuals : 6;
 
     /// True if this dimension included the 'static' keyword.

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -1405,7 +1405,7 @@ public:
 
   QualType BuildQualifiedType(QualType T, SourceLocation Loc, Qualifiers Qs,
                               const DeclSpec *DS = nullptr);
-  QualType BuildQualifiedType(QualType T, SourceLocation Loc, unsigned CVRAM,
+  QualType BuildQualifiedType(QualType T, SourceLocation Loc, unsigned CVRAC,
                               const DeclSpec *DS = nullptr); // Updated for Checked C
   QualType BuildPointerType(QualType T, CheckedPointerKind kind,
                             SourceLocation Loc, DeclarationName Entity);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1987,11 +1987,11 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
     break;
   case Type::Pointer:
     AS = getTargetAddressSpace(cast<PointerType>(T)->getPointeeType());
+    // Checked C:  MMSafe pointers have different size and memory alignment
+    // than raw C pointers.
     if (T->isCheckedPointerMMSafeType()) {
-      // Checked C:  MMSafe pointers have different size and memory alignment
-      // than raw C pointers.
-      Width = Target->getPointerWidth(AS, T);
-      Align = Target->getPointerAlign(AS, T);
+      Width = Target->getPointerWidth(AS, true);
+      Align = Target->getPointerAlign(AS, true);
     } else {
       Width = Target->getPointerWidth(AS);
       Align = Target->getPointerAlign(AS);
@@ -9652,7 +9652,8 @@ bool ASTContext::isEqualIgnoringChecked(QualType T1, QualType T2) const {
 // specification.
 bool ASTContext::isNotAllowedForNoPrototypeFunction(QualType QT) const {
   if (const PointerType *PT = QT->getAs<PointerType>()) {
-    // Checked C & FIXME: Checked C does not allow the return typf of a
+    // Checked C
+    // FIXME: Checked C does not allow the return type of a
     // no-prototype function to be a spatial memory safe pointer.
     // Currently, for the sake of easy development, we allow MMSafe pointers
     // to be returnd by a no-prototype function. Since the MMSafe pointer

--- a/lib/CodeGen/Address.h
+++ b/lib/CodeGen/Address.h
@@ -32,7 +32,7 @@ private:
   bool _isMMArrayPtr = false;
   bool _isMMSafePtr = false;
   llvm::Type *originalPointerTy;
-  llvm::Type *rawPointerTy;  // The inner pointer type of a _MM_ptr.
+  llvm::Type *rawPointerTy;  // The inner pointer type of an MMSafe ptr.
 
 public:
   Address(llvm::Value *pointer, CharUnits alignment)
@@ -48,6 +48,8 @@ public:
       // to be the inner raw pointer type. Without this mutation,
       // pointer dereference would fail because the compiler would try to
       // dereference an llvm::StructType.
+      // We fixed type mismatch problems caused by this mutation in the
+      // pass CheckedCHarmonizeTypePass.
       if (pointer->getType()->isMMPointerTy()) {
         _isMMPtr = true;
         rawPointerTy = pointer->getType()->getMMPtrInnerPtrTy();

--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -33,7 +33,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/IR/Verifier.h"
-#include "llvm/IR/CheckedCAddLockToMultiple.h"
+#include "llvm/IR/CheckedCAddLockToCheckable.h"
 #include "llvm/IR/CheckedCHarmonizeType.h"
 #include "llvm/LTO/LTOBackend.h"
 #include "llvm/MC/MCAsmInfo.h"
@@ -663,9 +663,9 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
   }
 
   // Checked C
-  // Run this pass to create a lock for each _multiple stack & global object.
-  if (CodeGenOpts.CheckedCAddLockToMultiple) {
-    MPM.add(createCheckedCAddLockToMultiplePass());
+  // Run this pass to create a lock for each _checkable stack & global object.
+  if (CodeGenOpts.CheckedCAddLockToCheckable) {
+    MPM.add(createCheckedCAddLockToCheckablePass());
   }
 
   // Checked C

--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -244,8 +244,8 @@ llvm::Constant *CodeGenModule::getOrCreateStaticVarDecl(
       getModule(), LTy, Ty.isConstant(getContext()), Linkage, Init, Name,
       nullptr, llvm::GlobalVariable::NotThreadLocal, TargetAS);
   GV->setAlignment(getContext().getDeclAlign(&D).getQuantity());
-  // Checked C: set the _multiple
-  GV->setMultipleQualified(D.getType().isMultipleQualified());
+  // Checked C: set the _checkable
+  GV->setCheckableQualified(D.getType().isCheckableQualified());
 
   if (supportsCOMDAT() && GV->isWeakForLinker())
     GV->setComdat(TheModule.getOrInsertComdat(GV->getName()));
@@ -1412,10 +1412,10 @@ CodeGenFunction::EmitAutoVarAlloca(const VarDecl &D) {
       // builds.
       address = CreateTempAlloca(allocaTy, allocaAlignment, D.getName(),
                                  /*ArraySize=*/nullptr, &AllocaAddr);
-      // Checked C: set _multiple for a stack variable.
-      // Are there any other places we need set the _multiple for an AllocaInst?
-      cast<llvm::AllocaInst>(address.getPointer())->setMultipleQualified(
-          Ty.isMultipleQualified());
+      // Checked C: set _checkable for a stack variable.
+      // Are there any other places we need set the _checkable for an AllocaInst?
+      cast<llvm::AllocaInst>(address.getPointer())->setCheckableQualified(
+          Ty.isCheckableQualified());
 
       // Don't emit lifetime markers for MSVC catch parameters. The lifetime of
       // the catch parameter starts in the catchpad instruction, and we can't

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2940,7 +2940,7 @@ public:
   void EmitDynamicCheckBlocks(llvm::Value *Condition);
   void EmitDynamicKeyCheckResult(llvm::Value *Condition);
   void EmitDynamicKeyCheck(const Expr *E);
-  llvm::Function* GetOrInsertKeyCheckFn(bool isMMPtr = true);
+  llvm::Function* GetOrInsertKeyCheckFn();
   llvm::BasicBlock *EmitDynamicCheckFailedBlock();
   llvm::BasicBlock *EmitNulltermWriteAdditionalCheck(const Address PtrAddr,
                                                      const Address Upper,

--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -3081,8 +3081,8 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName,
       getModule(), Ty->getElementType(), false,
       llvm::GlobalValue::ExternalLinkage, nullptr, MangledName, nullptr,
       llvm::GlobalVariable::NotThreadLocal, TargetAddrSpace);
-  // Checked C: set _multiple if it is.
-  GV->setMultipleQualified(D->getType().isMultipleQualified());
+  // Checked C: set _checkable if it is.
+  GV->setCheckableQualified(D->getType().isCheckableQualified());
 
   // If we already created a global with the same mangled name (but different
   // type) before, take its name and remove it from its parent.

--- a/lib/CodeGen/CodeGenTypes.cpp
+++ b/lib/CodeGen/CodeGenTypes.cpp
@@ -549,11 +549,11 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     unsigned AS = Context.getTargetAddressSpace(ETy);
 
     if (PTy->isCheckedPointerMMType()) {
-      // Checked C: build a _MM_ptr pointer.
+      // Checked C: build an _MM_ptr pointer.
       ResultType = llvm::PointerType::getMMPtr(PointeeType,
                                                getLLVMContext(), AS);
     } else if (PTy->isCheckedPointerMMArrayType()) {
-      // Checked C: build a _MM_array_ptr pointer.
+      // Checked C: build an _MM_array_ptr pointer.
       ResultType = llvm::PointerType::getMMArrayPtr(PointeeType,
                                                     getLLVMContext(), AS);
     } else {

--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -2583,13 +2583,11 @@ void X86_64ABIInfo::classify(QualType Ty, uint64_t OffsetBase,
 
     // Checked C:
     // A raw C pointer is 8-byte long on X86-64 and it only needs to set
-    // the Lo part to be Integer.  _MM_ptr also needs to set the Hi part
-    // for its ID, and _MM_array_ptr has 192-bit and thus it should be
-    // passed by memory. Note we only implemented for X86-64 ABI for now.
-    if (Ty->isCheckedPointerMMType()) {
+    // the Lo part to be Integer.  MMSafePtr need to set both parts
+    // to Integer.
+    // Note we only implemented for X86-64 ABI for now.
+    if (Ty->isCheckedPointerMMSafeType()) {
       Hi = Integer;
-    } else if (Ty->isCheckedPointerMMArrayType()) {
-      Current = Memory;    // Lo = Memory
     }
 
     return;
@@ -2883,8 +2881,7 @@ ABIArgInfo X86_64ABIInfo::getIndirectReturnResult(QualType Ty) const {
   // If this is a scalar LLVM value then assume LLVM will pass it in the right
   // place naturally.
 
-  // Checked C: _MM_array_ptr is returned by memory.
-  if (!isAggregateTypeForABI(Ty) && !Ty->isCheckedPointerMMArrayType()) {
+  if (!isAggregateTypeForABI(Ty)) {
     // Treat an enum type as its underlying type.
     if (const EnumType *EnumTy = Ty->getAs<EnumType>())
       Ty = EnumTy->getDecl()->getIntegerType();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3909,9 +3909,9 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
                                  getLangOpts());
       break;
 
-    // Checked C: _multiple
-    case tok::kw__multiple:
-      isInvalid = DS.SetTypeQual(DeclSpec::TQ_multiple, Loc, PrevSpec, DiagID,
+    // Checked C: _checkable
+    case tok::kw__checkable:
+      isInvalid = DS.SetTypeQual(DeclSpec::TQ_checkable, Loc, PrevSpec, DiagID,
                                  getLangOpts());
       break;
 
@@ -5034,7 +5034,7 @@ bool Parser::isTypeSpecifierQualifier() {
   case tok::kw_volatile:
   case tok::kw_restrict:
   case tok::kw__Sat:
-  case tok::kw__multiple:  // Checked C
+  case tok::kw__checkable:  // Checked C
 
     // Debugger support.
   case tok::kw___unknown_anytype:
@@ -5201,7 +5201,7 @@ bool Parser::isDeclarationSpecifier(bool DisambiguatingWithExpression) {
   case tok::kw_volatile:
   case tok::kw_restrict:
   case tok::kw__Sat:
-  case tok::kw__multiple:  // Checked C
+  case tok::kw__checkable:  // Checked C
 
     // function-specifier
   case tok::kw_inline:
@@ -5486,8 +5486,8 @@ void Parser::ParseTypeQualifierListOpt(
                                  getLangOpts());
       break;
     // Checked C
-    case tok::kw__multiple:
-      isInvalid = DS.SetTypeQual(DeclSpec::TQ_multiple, Loc, PrevSpec, DiagID,
+    case tok::kw__checkable:
+      isInvalid = DS.SetTypeQual(DeclSpec::TQ_checkable, Loc, PrevSpec, DiagID,
                                  getLangOpts());
 
     // OpenCL qualifiers:

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2717,8 +2717,8 @@ void CastOperation::CheckCStyleCast(bool IsCheckedScope) {
 
   // Checked C
   // Disallow cast a non-MMSafe pointer type to an MMSafe pointer type.
-  // JZ: What does "SrcExpr.get()->getSourceRange();" do at line 2710? The
-  // error message looks the same without this getSourceRange().
+  // Jie Zhou: What does "SrcExpr.get()->getSourceRange();" do at line 2710?
+  // The error message looks the same without this getSourceRange().
   if (DestType->isCheckedPointerMMSafeType() &&
       !SrcType->isCheckedPointerMMSafeType()) {
     Self.Diag(SrcExpr.get()->getExprLoc(),

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -4170,7 +4170,7 @@ void Sema::MergeVarDeclTypes(VarDecl *New, VarDecl *Old,
   } else {
     // C 6.2.7p2:
     //   All declarations that refer to the same object or function shall have
-    //   compatible type
+    //   compatible type.
     MergedT = Context.mergeTypes(New->getType(), Old->getType());
   }
   if (MergedT.isNull()) {
@@ -12217,7 +12217,7 @@ void Sema::ActOnUninitializedDecl(Decl *RealDecl) {
       else if (B && !B->isInvalid() && !B->isUnknown() && !Ty->isArrayType())
         Diag(Var->getLocation(), diag::err_initializer_expected_with_bounds)
           << Var;
-      else if (Ty->isCheckedPointerMMType())
+      else if (Ty->isCheckedPointerMMType())  // Checked C
         Diag(Var->getLocation(), diag::err_initializer_expected_for_mm_ptr)
           << Var;
       else if (Ty->isCheckedPointerMMArrayType())

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -7980,9 +7980,9 @@ static bool addrOfExprRetMMSafePtr(Expr *UOExpr) {
         break;
       case Expr::DeclRefExprClass:
         // Reached the top (leftmost) of the Expr.
-        // Getting the address of an _multiple stack/global object should
+        // Getting the address of a _checkable stack/global object should
         // return an mmsafe pointer.
-        return EType.isMultipleQualified() ? true : false;
+        return EType.isCheckableQualified() ? true : false;
       default:
         assert(0 && "Unknown Expr");
         break;
@@ -8134,8 +8134,8 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, ExprResult &RHS) {
     }
 #endif
 
-    // Checke if it is assigning an _multiple array to an mm_array_ptr.
-    if (lhkind == CheckedPointerKind::MMArray && rhq.hasMultiple()) {
+    // Checke if it is assigning an _checkable array to an mm_array_ptr.
+    if (lhkind == CheckedPointerKind::MMArray && rhq.hasCheckable()) {
       return Sema::Compatible;
     }
 
@@ -8401,7 +8401,7 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
   // to a raw pointer.
   //
   // FIXME? Should we allow or disallow 2.?
-  // 2. Disallow assigning the address of an _multiple object to a raw C pointer.
+  // 2. Disallow assigning the address of an _checkable object to a raw C pointer.
   //
   // FIXME: Currently the RHSType of the result of an addres-of expression
   // is always a raw pointer. For example, The type of "&p->i" is "int *" if
@@ -8412,7 +8412,7 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
   // To fix this issue, we need set the type of the RHS correctly at a much
   // earlier stage.
   // Plus, we would get a similarly confusing error message from assigning the
-  // address of an _multiple object to a raw C pointer.
+  // address of an _checkable object to a raw C pointer.
   if (isa<PointerType>(LHSType.getTypePtr()) &&
       isa<PointerType>(RHSType.getTypePtr())) {
     CheckedPointerKind lhkind = cast<PointerType>(LHSType)->getKind();
@@ -8420,7 +8420,7 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
 
     if (lhkind == CheckedPointerKind::Unchecked &&
         rhkind == CheckedPointerKind::Unchecked) {
-      if (RHSType->getPointeeType().isMultipleQualified()) {
+      if (RHSType->getPointeeType().isCheckableQualified()) {
         // Again, should we allow or disallow this?
         return Sema::Incompatible;
       }


### PR DESCRIPTION
Updated the implementation of mm_array_ptr<T> from the 3-field
structure, i.e., `{T (raw_ptr, uint64_t key, uint64_t *lock_addr}` to
the 2-field mm_array_ptr<T>, i.e., `{T *raw_ptr, uint64_t key-offset}`,
which is the same as the structure of mm_ptr<T>. This should make
most array pointer intensive programs faster.

The current implementation passed the small tests, Olden benchmarks,
`parson`, and `thttpd` (on Linux).