### PR TITLE
Implemented assigning the address of a stack or global object to an mmsafe pointer.

### DIFF
--- a/include/clang/AST/ASTConsumer.h
+++ b/include/clang/AST/ASTConsumer.h
@@ -139,6 +139,10 @@ public:
   /// body may be parsed anyway if it is needed (for instance, if it contains
   /// the code completion point or is constexpr).
   virtual bool shouldSkipFunctionBody(Decl *D) { return true; }
+
+  /// Handle Checked C related stuffs, such as adding locks for address taken
+  /// variables. It is actually implemented in BackendConsumer.
+  virtual void HandleCheckedCForTemporalMemSafety() {}
 };
 
 } // end namespace clang.

--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -35,6 +35,7 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/IR/CheckedCAddLockToCheckable.h"
 #include "llvm/IR/CheckedCHarmonizeType.h"
+#include "llvm/IR/CheckedCSecureStack.h"
 #include "llvm/LTO/LTOBackend.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/SubtargetFeature.h"
@@ -674,6 +675,10 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
   if (CodeGenOpts.CheckedCHarmonizeType) {
     FPM.add(createCheckedCHarmonizeTypePass());
   }
+
+  // Checked C
+  // Add temporal memory safety for address-taken local variables.
+  FPM.add(createCheckedCSecureStackPass());
 
   // Set up the per-function pass manager.
   FPM.add(new TargetLibraryInfoWrapperPass(*TLII));

--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -1720,21 +1720,22 @@ llvm::Value *CodeGenFunction::EmitFromMemory(llvm::Value *Value, QualType Ty) {
 //   A ConstantStruct representing an MMArrayPtr with @StrGEP as the first field.
 //
 llvm::Value *CodeGenFunction::
-EmitMMArrayPtrForStrConst(llvm::Value *StrGEP) {
-  using Constant = llvm::Constant;
-  using StructType = llvm::StructType;
-  using Value = llvm::Value;
+EmitMMArrayPtrForStrConst(llvm::GEPOperator *StrGEP) {
+  llvm::ConstantExpr *CE = dyn_cast<llvm::ConstantExpr>(StrGEP);
+  assert((CE && CE->getOpcode() == llvm::Instruction::GetElementPtr) &&
+         "Not a GetElementPtrConstantExpr");
   llvm::Type *Int64Ty = Builder.getInt64Ty();
 
   // Create an MMArrayPtr constant.
-  StructType *ST = StructType::get(StrGEP->getType(), Int64Ty);
+  llvm::StructType *ST = llvm::StructType::get(StrGEP->getType(), Int64Ty);
   ST->isMMArrayPtr = true;
-  Value *KeyOffset = Builder.CreateShl(llvm::ConstantInt::get(Int64Ty, 2),
-                                          32, "KeyOffset");
+  llvm::Value *KeyOffset = Builder.CreateShl(llvm::ConstantInt::get(Int64Ty, 1),
+                                             32, "KeyOffset");
+  cast<llvm::GlobalVariable>(StrGEP->getPointerOperand())->setPointedByMMSafePtr();
   // The cast in the constructor should be safe because StrGEP should be an
   // llvm::GetElementPtrConstantExpr.
-  return llvm::ConstantStruct::get(ST, {cast<Constant>(StrGEP),
-                                        cast<Constant>(KeyOffset)});
+  return llvm::ConstantStruct::get(ST, {cast<llvm::Constant>(StrGEP),
+                                        cast<llvm::Constant>(KeyOffset)});
 }
 
 void CodeGenFunction::EmitStoreOfScalar(llvm::Value *Value, Address Addr,
@@ -1786,8 +1787,8 @@ void CodeGenFunction::EmitStoreOfScalar(llvm::Value *Value, Address Addr,
       if (GV && GV->isConstant() && GEP->getResultElementType()->isIntegerTy(8)
           && Addr.getElementType()->isMMArrayPointerTy()) {
         // Checked C: Directly assigning an string constant to an MMArrayPtr.
-        // Since string constants are stored as private globals, we treat them
-        // as _checkable global variables.
+        // String constants are stored as private globals, we treat them
+        // as address-taken global variables.
         //
         // Jie Zhou: The checks in this if statement might be redundant. If
         // the execution reaches to the outside if condition, it should be
@@ -1796,8 +1797,7 @@ void CodeGenFunction::EmitStoreOfScalar(llvm::Value *Value, Address Addr,
         //
         // TODO: The type checker should forbid assigning a string constant
         // to an MMPtr, while it does not enforce it now.
-        GV->setCheckableQualified(true);
-        Value = EmitMMArrayPtrForStrConst(Value);
+        Value = EmitMMArrayPtrForStrConst(GEP);
       }
     }
   }

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -429,7 +429,7 @@ public:
   Value *EmitMMSafePtrToCheckableObj(Value *Val, bool isAddrOf=false);
 
   // Checked C: Emit an mmsafe ptr to an address-taken local variable.
-  Value *EmitMMSafePtrToAddressTakenVar(Value *Val, bool isAddrOf=false);
+  Value *EmitMMSafePtrToAddressTakenVar(Value *Val);
 
   //===--------------------------------------------------------------------===//
   //                            Visitor Methods
@@ -1965,54 +1965,93 @@ Value *ScalarExprEmitter::EmitMMSafePtrToCheckableObj(Value *Val, bool isAddrOf)
 //
 // Checked C
 // Emit an MMSafe pointer to an address-taken local or global object.
+// There are two cases. The first is an arithmetic expression of an array
+// (including using the name of the array, which is equivalent to "+ 0").
+// The second is an address-of expression of a variable.
 //
-// TODO: Currently we have only support for arithmetic expression on
-// a local or global array. We need implement generating an mmsafe pointer
-// from an address-of expression.
+// TODO: Add support for global variables.
 //
 Value *
-ScalarExprEmitter::EmitMMSafePtrToAddressTakenVar(Value *Val, bool isAddrOf) {
+ScalarExprEmitter::EmitMMSafePtrToAddressTakenVar(Value *Val) {
   using StructType = llvm::StructType;
   using PointerType = llvm::PointerType;
   using GEPOperator = llvm::GEPOperator;
+  using UndefValue = llvm::UndefValue;
+  using AllocaInst = llvm::AllocaInst;
+  using ArrayType = llvm::ArrayType;
+  const llvm::DataLayout &DL = CGF.CGM.getDataLayout();
   unsigned AS = Val->getType()->getPointerAddressSpace();
   llvm::LLVMContext &llvmContext = CGF.getLLVMContext();
 
-  if (!isAddrOf) {
-    // The Val is an arithmetic expression of an array.
-    GEPOperator *GEP = dyn_cast<GEPOperator>(Val);
-    assert(GEP && "Not a GEP");
-    Value *GEPPtr = GEP->getPointerOperand();
-    if (isa<GEPOperator>(GEPPtr)) {
-      // Do this need to be in a loop?
-      GEPPtr = cast<GEPOperator>(GEPPtr)->getPointerOperand();
-    }
-
-    Value *Index;    // The numberic value of the arithmetic expression.
-    switch(GEP->getNumIndices()) {
-      case 1:
-        Index = GEP->getOperand(1);
-        break;
-      case 2:
-        // Does this case ever get triggered?
-        Index = GEP->getOperand(2);
-        break;
-      default:
-        assert(0 && "Unknown GEP Indices");
-        break;
-    }
-
-    // The initial offset is the offset (bytes) of the arith-expr.
-    // The key is now a placeholder. It will be set by the CheckedCSecureStackPass.
-    Value *KeyOffset = GetOffsetOfArithExpr(CGF, GEP, Index);
-    // Create an MMArrayPtr.
-    StructType *MMArrayPtrTy =
-      PointerType::getMMArrayPtr(GEP->getResultElementType(), llvmContext, AS);
-    Val = Builder.CreateInsertValue(llvm::UndefValue::get(MMArrayPtrTy), Val, 0);
+  if (AllocaInst *AI = dyn_cast<AllocaInst>(Val)) {
+    // The Val is from directly getting the address of a var, e.g., "&num".
+    Value *KeyOffset = Builder.getInt64(0);
+    StructType *MMPtrTy =
+      PointerType::getMMPtr(AI->getAllocatedType(), llvmContext, AS);
+    Val = Builder.CreateInsertValue(UndefValue::get(MMPtrTy), Val, 0);
     return Builder.CreateInsertValue(Val, KeyOffset, 1);
   }
 
-  assert(0 && "Unhandled case(s)");
+  // Handle an address-taken or pointer-arithmetic expression.
+
+  // Find out if Val is from a arith expr or an addr-of expr.
+  // Until now all the arith GEP only have one index except for the one
+  // whose pointer operand is an array variable, and all addr-of expr GEP
+  // has 2 indices before any optimization.
+  // Let's just do the implementation based on these assumptions.
+  GEPOperator *GEP = cast<GEPOperator>(Val);
+  Value *Offset = Builder.getInt64(0);
+  bool isPtrArithExpr = true;
+  StructType *MMSafePtrTy;
+  llvm::Type *PointeeTy = GEP->getResultElementType();
+  // Verify the assumptions stated above.
+  if (GEP->getNumIndices() == 1) {
+    while ((GEP = dyn_cast<GEPOperator>(GEP->getPointerOperand()))) {
+      assert((GEP->getNumIndices() == 1 || (GEP->getNumIndices() == 2 &&
+              isa<ArrayType>(GEP->getSourceElementType())))
+             && "Unknown GEP indices");
+    }
+    MMSafePtrTy = PointerType::getMMArrayPtr(PointeeTy, llvmContext, AS);
+  } else if (GEP->getNumIndices() == 2) {
+    while ((GEP = dyn_cast<GEPOperator>(GEP->getPointerOperand()))) {
+      assert(GEP->getNumIndices() == 2 && "Unknown GEP indices");
+    }
+    isPtrArithExpr = false;
+    MMSafePtrTy = PointerType::getMMPtr(PointeeTy, llvmContext, AS);
+  } else {
+    assert(0 && "Unknow GEP Indices");
+  }
+
+  GEP = cast<GEPOperator>(Val);
+  if (isPtrArithExpr) {
+    while (GEP) {
+      Offset = Builder.CreateAdd(Offset,
+          GetOffsetOfArithExpr(CGF, GEP, GEP->getOperand(1)));
+      GEP = dyn_cast<GEPOperator>(GEP->getPointerOperand());
+    }
+  } else {
+    while (GEP) {
+      Value *Index = GEP->getOperand(2);
+      // If the first index is not 0, add sizeof(struct) * firstIdx to Offset.
+      assert(cast<ConstantInt>(GEP->getOperand(1))->isZero() &&
+          "The first index of the GEP is not 0");
+      llvm::Type *GEPElemTy = GEP->getSourceElementType();
+      if (StructType *ST = dyn_cast<StructType>(GEPElemTy)) {
+        Offset = Builder.CreateAdd(Offset, GetStructElemOffset(ST, Index, DL));
+      } else if (ArrayType *AT = dyn_cast<ArrayType>(GEPElemTy)) {
+        Offset = Builder.CreateAdd(Offset, GetArrayElemOffset(AT, Index, DL));
+      } else {
+        assert(0 && "Unknown GEP Element Type");
+      }
+      GEP = dyn_cast<GEPOperator>(GEP->getPointerOperand());
+    }
+  }
+
+  // The initial offset for the mmsafe pointer is the offset (bytes) of the
+  // arith-expr or addr-of expr. The key is now only a placeholder. It will be
+  // set by the CheckedCSecureStackPass.
+  Val = Builder.CreateInsertValue(llvm::UndefValue::get(MMSafePtrTy), Val, 0);
+  return Builder.CreateInsertValue(Val, Offset, 1);
 }
 
 /// Emit a sanitization check for the given "binary" operation (which
@@ -2529,10 +2568,13 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
           return EmitMMSafePtrToCheckableObj(Src);
         }
 
-        // Should be from assigning the result of an arith-expr on an
-        // address-taken variable to a checked pointer.
-        assert(isa<GetElementPtrInst>(Src));
-        return EmitMMSafePtrToAddressTakenVar(Src);
+        if (isa<GetElementPtrInst>(Src) || isa<llvm::AllocaInst>(Src)) {
+        // The RHS should be assigning
+        //   1. an arith-expr of an address-taken variable to an mmsafe ptr.
+        //   2. an addr-of expr on a fild of a struct variable to an mmsafe ptr.
+          return EmitMMSafePtrToAddressTakenVar(Src);
+        }
+        assert(0 && "Unknown Instruction");
       }
     } else if (SrcTy->isMMSafePointerTy() && DstTy->isPointerTy()) {
       // Checked C: Cast an mmsafe pointer to a raw C pointer.

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -429,7 +429,9 @@ public:
   Value *EmitMMSafePtrToCheckableObj(Value *Val, bool isAddrOf=false);
 
   // Checked C: Emit an mmsafe ptr to an address-taken local variable.
-  Value *EmitMMSafePtrToAddressTakenVar(Value *Val);
+  Value *EmitMMSafePtrToLocalAddrTakenVar(Value *Val);
+  // Checked C: Emit an mmsafe ptr to an address-taken global variable.
+  Value *EmitMMSafePtrToGlobalAddrTakenVar(Value *Val);
 
   //===--------------------------------------------------------------------===//
   //                            Visitor Methods
@@ -1969,26 +1971,22 @@ Value *ScalarExprEmitter::EmitMMSafePtrToCheckableObj(Value *Val, bool isAddrOf)
 // (including using the name of the array, which is equivalent to "+ 0").
 // The second is an address-of expression of a variable.
 //
-// TODO: Add support for global variables.
-//
 Value *
-ScalarExprEmitter::EmitMMSafePtrToAddressTakenVar(Value *Val) {
+ScalarExprEmitter::EmitMMSafePtrToLocalAddrTakenVar(Value *Val) {
   using StructType = llvm::StructType;
   using PointerType = llvm::PointerType;
   using GEPOperator = llvm::GEPOperator;
-  using UndefValue = llvm::UndefValue;
-  using AllocaInst = llvm::AllocaInst;
   using ArrayType = llvm::ArrayType;
   const llvm::DataLayout &DL = CGF.CGM.getDataLayout();
   unsigned AS = Val->getType()->getPointerAddressSpace();
   llvm::LLVMContext &llvmContext = CGF.getLLVMContext();
 
-  if (AllocaInst *AI = dyn_cast<AllocaInst>(Val)) {
+  if (llvm::AllocaInst *AI = dyn_cast<llvm::AllocaInst>(Val)) {
     // The Val is from directly getting the address of a var, e.g., "&num".
     Value *KeyOffset = Builder.getInt64(0);
     StructType *MMPtrTy =
       PointerType::getMMPtr(AI->getAllocatedType(), llvmContext, AS);
-    Val = Builder.CreateInsertValue(UndefValue::get(MMPtrTy), Val, 0);
+    Val = Builder.CreateInsertValue(llvm::UndefValue::get(MMPtrTy), Val, 0);
     return Builder.CreateInsertValue(Val, KeyOffset, 1);
   }
 
@@ -2052,6 +2050,76 @@ ScalarExprEmitter::EmitMMSafePtrToAddressTakenVar(Value *Val) {
   // set by the CheckedCSecureStackPass.
   Val = Builder.CreateInsertValue(llvm::UndefValue::get(MMSafePtrTy), Val, 0);
   return Builder.CreateInsertValue(Val, Offset, 1);
+}
+
+//
+// Checked C
+// Emit an MMSafe pointer to an address-taken global variable.
+// There are two cases. Frist, address-of expressions. Second, pointer arithmetic
+// expressions. Directly assigning a string constant to an mm_array_ptr<char>
+// is handled separately.
+//
+Value *ScalarExprEmitter::EmitMMSafePtrToGlobalAddrTakenVar(Value *Val) {
+  using GlobalVariable = llvm::GlobalVariable;
+  using GEPOperator = llvm::GEPOperator;
+  const llvm::DataLayout &DL = CGF.CGM.getDataLayout();
+  unsigned AS = Val->getType()->getPointerAddressSpace();
+  llvm::LLVMContext &llvmContext = CGF.getLLVMContext();
+
+  StructType *MMSafePtrTy = nullptr;
+  Value *KeyOffset = Builder.getInt64(1ul << 32);
+  if (isa<GlobalVariable>(Val)) {
+    // Should be from directly getting the address of a global variable,
+    // e.g., p = &num; where num is a global int.
+    MMSafePtrTy = llvm::PointerType::getMMPtr(
+        cast<GlobalVariable>(Val)->getValueType(), llvmContext, AS);
+    cast<GlobalVariable>(Val)->setPointedByMMSafePtr();
+  } else {
+    GEPOperator *GEP = cast<GEPOperator>(Val);
+    llvm::Type *GEPElemTy = GEP->getSourceElementType();
+    if (isa<GlobalVariable>(GEP->getPointerOperand())) {
+      // Should be from getting the address of an inner object of a global var.
+      cast<GlobalVariable>(GEP->getPointerOperand())->setPointedByMMSafePtr();
+
+      // If the first index is not 0, add sizeof(struct) * firstIdx to Offset.
+      assert(cast<ConstantInt>(GEP->getOperand(1))->isZero() &&
+          "The first index of the GEP is not 0");
+      for (unsigned i = 2; i <= GEP->getNumIndices(); i++) {
+        Value *Index = GEP->getOperand(i);
+        if (StructType *ST = dyn_cast<StructType>(GEPElemTy)) {
+          KeyOffset = Builder.CreateAdd(KeyOffset,
+              GetStructElemOffset(ST, Index, DL));
+          GEPElemTy = ST->getTypeAtIndex(Index);
+        } else if (llvm::ArrayType *AT = dyn_cast<llvm::ArrayType>(GEPElemTy)) {
+          KeyOffset = Builder.CreateAdd(KeyOffset,
+              GetArrayElemOffset(AT, Index, DL));
+          GEPElemTy = AT->getElementType();
+        } else {
+          assert(0 && "Unknown GEP Srouce Element Type");
+        }
+      }
+    } else {
+      // Should be from an arithmetic expression of a global array.
+      while (true) {
+        KeyOffset = Builder.CreateAdd(KeyOffset,
+            GetOffsetOfArithExpr(CGF, GEP, GEP->getOperand(1)));
+        Value *GEPPtr = GEP->getPointerOperand();
+        if (GEPOperator *GEPO = dyn_cast<GEPOperator>(GEPPtr)) {
+          GEP = GEPO;
+        } else if (GlobalVariable *GV = dyn_cast<GlobalVariable>(GEPPtr)) {
+          GV->setPointedByMMSafePtr();
+          break;
+        } else {
+          assert(0 && "Unknown GEP");
+        }
+      }
+    }
+    MMSafePtrTy = llvm::PointerType::getMMArrayPtr(GEPElemTy, llvmContext, AS);
+  }
+
+  // Create an MMSafe pointer and return it.
+  Val = Builder.CreateInsertValue(llvm::UndefValue::get(MMSafePtrTy), Val, 0);
+  return Builder.CreateInsertValue(Val, KeyOffset, 1);
 }
 
 /// Emit a sanitization check for the given "binary" operation (which
@@ -2565,16 +2633,37 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
         if (DstTy->isMMArrayPointerTy() && SrcQualTy->isPointerType() &&
             SrcQualTy->getPointeeType().isCheckableQualified()) {
           // Create an MMArrayPtr from an arith-expr on a _checkable object.
-          return EmitMMSafePtrToCheckableObj(Src);
+          Src = EmitMMSafePtrToCheckableObj(Src);
         }
 
-        if (isa<GetElementPtrInst>(Src) || isa<llvm::AllocaInst>(Src)) {
-        // The RHS should be assigning
-        //   1. an arith-expr of an address-taken variable to an mmsafe ptr.
-        //   2. an addr-of expr on a fild of a struct variable to an mmsafe ptr.
-          return EmitMMSafePtrToAddressTakenVar(Src);
+        // Should be getting the address of a local or global variable.
+        using GEPOperator = llvm::GEPOperator;
+        bool isLocalVar;
+        if (isa<GetElementPtrInst>(Src)) {
+          // The RHS should be one of the follow two cases:
+          //   1. an arith-expr of an address-taken variable
+          //   2. an addr-of expr on a fild of a struct variable
+          //
+          // Determine if this is from a local or global variable.
+          Value *GEPPtr = cast<GetElementPtrInst>(Src);
+          while (isa<GEPOperator>(GEPPtr)) {
+            GEPPtr = cast<GEPOperator>(GEPPtr)->getPointerOperand();
+          }
+          isLocalVar = !isa<llvm::GlobalVariable>(GEPPtr);
+        } else if (isa<llvm::AllocaInst>(Src)) {
+          // The RHS should be using the addr-of operator to directly get the
+          // address of a local variable.
+          isLocalVar = true;
+        } else if (isa<llvm::GlobalVariable>(Src) || isa<GEPOperator>(Src)) {
+          // The RHS should be directly getting the address of a global variable,
+          // "p = &len"; or "p = buf;" where buf is an array.
+          isLocalVar = false;
+        } else {
+          assert(0 && "Unknown Instruction");
         }
-        assert(0 && "Unknown Instruction");
+        Src = isLocalVar ? EmitMMSafePtrToLocalAddrTakenVar(Src) :
+                           EmitMMSafePtrToGlobalAddrTakenVar(Src);
+        return Builder.CreateMMSafePtrCast(Src, DstTy);
       }
     } else if (SrcTy->isMMSafePointerTy() && DstTy->isPointerTy()) {
       // Checked C: Cast an mmsafe pointer to a raw C pointer.

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -428,6 +428,9 @@ public:
   // Checked C: Emit an mmsafe ptr to a _checkable stack/global object.
   Value *EmitMMSafePtrToCheckableObj(Value *Val, bool isAddrOf=false);
 
+  // Checked C: Emit an mmsafe ptr to an address-taken local variable.
+  Value *EmitMMSafePtrToAddressTakenVar(Value *Val, bool isAddrOf=false);
+
   //===--------------------------------------------------------------------===//
   //                            Visitor Methods
   //===--------------------------------------------------------------------===//
@@ -1959,6 +1962,59 @@ Value *ScalarExprEmitter::EmitMMSafePtrToCheckableObj(Value *Val, bool isAddrOf)
   return Builder.CreateInsertValue(insertPtr, KeyOffset, 1);
 }
 
+//
+// Checked C
+// Emit an MMSafe pointer to an address-taken local or global object.
+//
+// TODO: Currently we have only support for arithmetic expression on
+// a local or global array. We need implement generating an mmsafe pointer
+// from an address-of expression.
+//
+Value *
+ScalarExprEmitter::EmitMMSafePtrToAddressTakenVar(Value *Val, bool isAddrOf) {
+  using StructType = llvm::StructType;
+  using PointerType = llvm::PointerType;
+  using GEPOperator = llvm::GEPOperator;
+  unsigned AS = Val->getType()->getPointerAddressSpace();
+  llvm::LLVMContext &llvmContext = CGF.getLLVMContext();
+
+  if (!isAddrOf) {
+    // The Val is an arithmetic expression of an array.
+    GEPOperator *GEP = dyn_cast<GEPOperator>(Val);
+    assert(GEP && "Not a GEP");
+    Value *GEPPtr = GEP->getPointerOperand();
+    if (isa<GEPOperator>(GEPPtr)) {
+      // Do this need to be in a loop?
+      GEPPtr = cast<GEPOperator>(GEPPtr)->getPointerOperand();
+    }
+
+    Value *Index;    // The numberic value of the arithmetic expression.
+    switch(GEP->getNumIndices()) {
+      case 1:
+        Index = GEP->getOperand(1);
+        break;
+      case 2:
+        // Does this case ever get triggered?
+        Index = GEP->getOperand(2);
+        break;
+      default:
+        assert(0 && "Unknown GEP Indices");
+        break;
+    }
+
+    // The initial offset is the offset (bytes) of the arith-expr.
+    // The key is now a placeholder. It will be set by the CheckedCSecureStackPass.
+    Value *KeyOffset = GetOffsetOfArithExpr(CGF, GEP, Index);
+    // Create an MMArrayPtr.
+    StructType *MMArrayPtrTy =
+      PointerType::getMMArrayPtr(GEP->getResultElementType(), llvmContext, AS);
+    Val = Builder.CreateInsertValue(llvm::UndefValue::get(MMArrayPtrTy), Val, 0);
+    return Builder.CreateInsertValue(Val, KeyOffset, 1);
+  }
+
+  assert(0 && "Unhandled case(s)");
+}
+
 /// Emit a sanitization check for the given "binary" operation (which
 /// might actually be a unary increment which has been lowered to a binary
 /// operation). The check passes if all values in \p Checks (which are \c i1),
@@ -2473,7 +2529,10 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
           return EmitMMSafePtrToCheckableObj(Src);
         }
 
-        assert(0 && "Casting improper type to MMSafe pointer.");
+        // Should be from assigning the result of an arith-expr on an
+        // address-taken variable to a checked pointer.
+        assert(isa<GetElementPtrInst>(Src));
+        return EmitMMSafePtrToAddressTakenVar(Src);
       }
     } else if (SrcTy->isMMSafePointerTy() && DstTy->isPointerTy()) {
       // Checked C: Cast an mmsafe pointer to a raw C pointer.

--- a/lib/CodeGen/CGStmt.cpp
+++ b/lib/CodeGen/CGStmt.cpp
@@ -1106,7 +1106,8 @@ void CodeGenFunction::EmitReturnStmt(const ReturnStmt &S) {
                    "Unknown global variable type");
             // Checked C:  This should be directly retuning a string constant
             // for an MMArrayPtr return type.
-            ConcreteRV = EmitMMArrayPtrForStrConst(ConcreteRV);
+            GV->setCheckableQualified(true);
+            ConcreteRV = EmitMMArrayPtrForStrConst(GEP);
           }
         }
         Builder.CreateStore(ConcreteRV, ReturnValue);

--- a/lib/CodeGen/CodeGenAction.cpp
+++ b/lib/CodeGen/CodeGenAction.cpp
@@ -225,6 +225,20 @@ namespace clang {
       return false; // success
     }
 
+    // Checked C
+    // Process Checked C related stuffs before running optimization passes.
+    //
+    // TODO/FIXME:
+    // 1. Move the CheckedCHarmonizeTypePass to CodeGenModule or CodeGenFunction
+    // and call its code from here.
+    // 2. Move the CheckedCSecureStackPass to CodeGenModule or CodeGenFunction
+    // and call its code from here.
+    // 3. Fix "_checkable" related code.
+    void HandleCheckedCForTemporalMemSafety() override {
+      // Add locks for global objects pointed by mmsafe pointers.
+      Gen->CGM().addLockToAddrTakenGlobalObj();
+    }
+
     void HandleTranslationUnit(ASTContext &C) override {
       {
         PrettyStackTraceString CrashInfo("Per-file LLVM IR generation");
@@ -235,6 +249,10 @@ namespace clang {
         }
 
         Gen->HandleTranslationUnit(C);
+
+        // Process Checked C related stuffs. This should be the earliest point
+        // after the initial complete IR code generation before optimizations.
+        HandleCheckedCForTemporalMemSafety();
 
         if (FrontendTimesIsEnabled) {
           LLVMIRGenerationRefCount -= 1;

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -2685,7 +2685,7 @@ public:
   llvm::DebugLoc SourceLocToDebugLoc(SourceLocation Location);
 
   /// Checked C: Emit an MMArrayPtr that points to a string constant.
-  llvm::Value *EmitMMArrayPtrForStrConst(llvm::Value *Str);
+  llvm::Value *EmitMMArrayPtrForStrConst(llvm::GEPOperator *Str);
 
   //===--------------------------------------------------------------------===//
   //                            Declaration Emission

--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -58,6 +58,8 @@
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MD5.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Constants.h"
 
 using namespace clang;
 using namespace CodeGen;
@@ -3661,7 +3663,6 @@ void CodeGenModule::EmitGlobalVarDefinition(const VarDecl *D,
       !llvm::GlobalVariable::isLinkOnceLinkage(Linkage) &&
       !llvm::GlobalVariable::isWeakLinkage(Linkage))
     Linkage = llvm::GlobalValue::InternalLinkage;
-
   GV->setLinkage(Linkage);
   if (D->hasAttr<DLLImportAttr>())
     GV->setDLLStorageClass(llvm::GlobalVariable::DLLImportStorageClass);
@@ -5508,4 +5509,82 @@ CodeGenModule::createOpenCLIntToSamplerConversion(const Expr *E,
   return CGF.Builder.CreateCall(CreateRuntimeFunction(FTy,
                                 "__translate_sampler_initializer"),
                                 {C});
+}
+
+//
+// Checked C
+// Method: addLockToAddrTakenGlobalObj()
+//
+// Add locks for address-taken global variables in a module.  Currently it adds
+// a lock for each address-taken global variable pointed by mmsafe pointer(s).
+//
+// A small optimization that can be done is to group global variables
+// that have the same attributes (linkage, constant, et.c) to one struct
+// and create one lock for the whole struct.
+//
+// Note that actually not EVERY address-taken global variable is processed.
+// We only care about address-taken variables that have at least one mmsafe
+// pointer point to them. If a global variable's address is taken and only
+// passed to a raw C pointer, this function ignores it.
+//
+void CodeGenModule::addLockToAddrTakenGlobalObj() {
+  using Constant = llvm::Constant;
+  using StructType = llvm::StructType;
+  using GlobalVariable = llvm::GlobalVariable;
+  CGBuilderTy Builder = CodeGenFunction(*this).Builder;
+  llvm::Module &M = getModule();
+  llvm::Type *Int64Ty = Builder.getInt64Ty();
+  std::vector<GlobalVariable *> addrTakenGVs;
+  Constant *Zero = Builder.getInt64(0), *Lock = Builder.getInt64(1);
+
+  // Collect all address-taken global variables.
+  for (GlobalVariable &GV : M.globals()) {
+    if (GV.isPointedByMMSafePtr() && !GV.isDeclaration()) {
+        addrTakenGVs.push_back(&GV);
+      if (GV.hasCommonLinkage()) {
+         // If a global variable is defined without explicit initialization,
+         // LLVM would set its linkage type to "common" and globals of
+         // common linkage must be initialized with zero initializer.
+         // Here we set it to ExternalLinkage because we would initialize
+         // it with a lock of value 1.
+         //
+         // Updated on 8/15: Do we really need this? From small test code I
+         // saw LLVM uses a zero initializer for global variabels even if
+         // they are not initialized in the source code.
+        GV.setLinkage(llvm::GlobalValue::ExternalLinkage);
+      }
+    }
+  }
+
+  for (GlobalVariable *GV : addrTakenGVs) {
+    unsigned AS = GV->getType()->getAddressSpace();
+    StructType *NewGVTy = nullptr;
+    Constant *NewGVInit = nullptr;
+    // Indices to GEP the new GV with the lock to get the original GV.
+    Constant *Indices[] = {Builder.getInt32(0), nullptr};
+    llvm::Type *GVTy = GV->getValueType();
+    Constant *GVInit = GV->getInitializer();
+    if (GVTy->isMMSafePointerTy()) {
+      // For mmsafe pointer global variables, we need ensure it is aligned
+      // by at least 16 bytes.
+      NewGVTy = StructType::get(Int64Ty, Int64Ty, GVTy);
+      NewGVInit = llvm::ConstantStruct::get(NewGVTy, {Zero, Lock, GVInit});
+      Indices[1] = Builder.getInt32(2);
+    } else {
+      NewGVTy = StructType::get(Int64Ty, GVTy);
+      NewGVInit = llvm::ConstantStruct::get(NewGVTy, {Lock, GVInit});
+      Indices[1] = Builder.getInt32(1);
+    }
+
+    // Create a struct that contains the lock and the original GV
+    GlobalVariable *GVWithLock =
+      new GlobalVariable(M, NewGVTy, GV->isConstant(), GV->getLinkage(),
+          NewGVInit, GV->getName() + "_addrTakenGlobals", nullptr,
+          GlobalVariable::NotThreadLocal, AS, GV->isExternallyInitialized());
+    if (GVTy->isMMSafePointerTy()) GVWithLock->setAlignment(16);
+    Constant *GEPToOriginGV =
+      llvm::ConstantExpr::getGetElementPtr(NewGVTy, GVWithLock, Indices);
+    GV->replaceAllUsesWith(GEPToOriginGV);
+    GV->eraseFromParent();
+  }
 }

--- a/lib/CodeGen/CodeGenModule.h
+++ b/lib/CodeGen/CodeGenModule.h
@@ -1328,6 +1328,9 @@ public:
   bool hasMMArrayPtrKeyCheckFn() const {
     return MMArrayPtrKeyCheckFn;
   }
+
+  /// Add locks to global objects pointed by mmsafe pointers.
+  void addLockToAddrTakenGlobalObj();
 private:
   llvm::Constant *GetOrCreateLLVMFunction(
       StringRef MangledName, llvm::Type *Ty, GlobalDecl D, bool ForVTable,

--- a/lib/CodeGen/ModuleBuilder.cpp
+++ b/lib/CodeGen/ModuleBuilder.cpp
@@ -163,39 +163,6 @@ namespace {
       for (DeclGroupRef::iterator I = DG.begin(), E = DG.end(); I != E; ++I)
         Builder->EmitTopLevelDecl(*I);
 
-#if 0
-      // Checked C: create the two key check functions if they do not exist.
-      // Because our key check optmization pass inserts key checks for
-      // function calls with mmsafe pointer arguments, when a module
-      // has such function calls but does not have dereferences to the types
-      // of mmsafe pointer arguments aforementioned, the compiler would not
-      // generate key check functions for such types of mmsafe pointers
-      // during CodeGenFunction::EmitDynamicKeyCheck(). Here the compiler
-      // ensures that it always generates the two key check functions for
-      // Checked C programs.  This may generate unneeded key check function(s),
-      // but it should be faster than first checking if there are dereferences
-      // to such mmsafe pointers before creating key check functions.
-      //
-      // FIXME: Putting this piece of code here is not ideal because it will
-      // be called many many times for a module and only one call is needed.
-      // We should find a better place to place this piece of code; or we can
-      // modify CodeGenFunction to create these function before calls with
-      // mmsafe pointers arguments during function generation, similar to
-      // what we did for inserting key checks.
-      if (Builder->getLangOpts().CheckedC) {
-        if (!Builder->hasMMPtrKeyCheckFn()) {
-          CodeGenFunction CGF(*Builder);
-          CGF.GetOrInsertKeyCheckFn();
-          Builder->setHasMMPtrKeyCheckFnTrue();
-        }
-        if (!Builder->hasMMArrayPtrKeyCheckFn()) {
-          CodeGenFunction CGF(*Builder);
-          CGF.GetOrInsertKeyCheckFn(false);
-          Builder->setHasMMArrayPtrKeyCheckFnTrue();
-        }
-      }
-#endif
-
       return true;
     }
 

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -7942,11 +7942,17 @@ ExprResult Sema::ActOnConditionalOp(SourceLocation QuestionLoc,
 // Checked C
 // This is a helper function for CheckAssignmentConstraints() and
 // checkPointerTypesForAssignment(). It parses an address-of expression
-// to see if it returns the address of something pointed by an mmsafe pointer.
+// to see if it should return an mmsafe pointer. There are two conditions
+// it should return an mmsafe pointer,
+//   1. the addr-of expr computes the address of an object pointed by an
+//     mmsafe pointer, and the LHS of the assignment is an mmsafe pointer.
+//   2. the addr-of expr computes the address of a local or global variable
+//     and the LHS of the assignment is an mmsafe pointer.
 //
 // @arg UOExpr - An address-of expression.
+// @arg isLHSUnchecked - If the LHS of the assignment is an unchecked pointer.
 //
-static bool addrOfExprRetMMSafePtr(Expr *UOExpr) {
+static bool addrOfExprRetMMSafePtr(Expr *UOExpr, bool isLHSUnchecked=false) {
   assert(UOExpr->isAddressOf() && "Not an Address-Of Expression ");
 
   Expr *E = cast<UnaryOperator>(UOExpr)->getSubExpr();
@@ -7976,8 +7982,10 @@ static bool addrOfExprRetMMSafePtr(Expr *UOExpr) {
         E = cast<UnaryOperator>(E)->getSubExpr();
         break;
       case Expr::DeclRefExprClass:
-        // Reached the top (leftmost) of the Expr.
-        return true;
+        // Reached the top (leftmost) of the Expr. The UOPexr should be directly
+        // getting the address of a variable. If the LHS of the assignment is an
+        // unchecked pointer, then the RHS should not return an mmsafe pointer.
+        return !isLHSUnchecked;
       default:
         assert(0 && "Unknown Expr");
         break;
@@ -8458,7 +8466,7 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
     if (lhkind == CheckedPointerKind::Unchecked &&
         rhkind == CheckedPointerKind::Unchecked) {
       Expr *RHSExpr = RHS.get();
-      if (RHSExpr->isAddressOf() && addrOfExprRetMMSafePtr(RHSExpr)) {
+      if (RHSExpr->isAddressOf() && addrOfExprRetMMSafePtr(RHSExpr, true)) {
         // Check if the RHS is an addr-of expression that returns
         // an mmsafe pointer.
           return Sema::Incompatible;
@@ -8467,8 +8475,8 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
         // If the RHS is a ternary expression (c ? a : b), then neither of
         // the results is allowed to return an mmsafe ptr.
         Expr *TrueExpr = CO->getTrueExpr(), *FalseExpr = CO->getFalseExpr();
-        if ((TrueExpr->isAddressOf() && addrOfExprRetMMSafePtr(TrueExpr)) ||
-            (FalseExpr->isAddressOf() && addrOfExprRetMMSafePtr(FalseExpr))) {
+        if ((TrueExpr->isAddressOf() && addrOfExprRetMMSafePtr(TrueExpr, true)) ||
+            (FalseExpr->isAddressOf() && addrOfExprRetMMSafePtr(FalseExpr, true))) {
             return Sema::Incompatible;
         }
       }

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -7953,10 +7953,7 @@ static bool addrOfExprRetMMSafePtr(Expr *UOExpr) {
   unsigned level = 0;   // Iteration level.
   while (true) {
     // Strip off casts and parentheses.
-    while (isa<CastExpr>(E) || isa<ParenExpr>(E)) {
-      E = isa<CastExpr>(E) ? cast<CastExpr>(E)->getSubExpr() :
-        cast<ParenExpr>(E)->getSubExpr();
-    }
+    E = E->IgnoreParenCasts();
 
     QualType EType = E->getType();
     if (level != 0 && EType->isPointerType()) {
@@ -7980,9 +7977,7 @@ static bool addrOfExprRetMMSafePtr(Expr *UOExpr) {
         break;
       case Expr::DeclRefExprClass:
         // Reached the top (leftmost) of the Expr.
-        // Getting the address of a _checkable stack/global object should
-        // return an mmsafe pointer.
-        return EType.isCheckableQualified() ? true : false;
+        return true;
       default:
         assert(0 && "Unknown Expr");
         break;
@@ -7995,8 +7990,6 @@ static bool addrOfExprRetMMSafePtr(Expr *UOExpr) {
 // Checked C
 // This is a helper function that checks if an Expr is a pointer arithmetic
 // expression on a local or global constant array.
-//
-// Question: Should we support dynamic local arrays?
 //
 // FIXME? Although the current implementation works for the programs we have
 // seen, it looks suspicious.
@@ -8447,9 +8440,6 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
   // 1. Disallow assigning mmsafe pointers generated from an '&' expression
   // to a raw pointer.
   //
-  // FIXME? Should we allow or disallow 2.?
-  // 2. Disallow assigning the address of an _checkable object to a raw C pointer.
-  //
   // FIXME: Currently the RHSType of the result of an addres-of expression
   // is always a raw pointer. For example, The type of "&p->i" is "int *" if
   // i is an integer, regardless of the pointer type of p. This would give
@@ -8467,11 +8457,6 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
 
     if (lhkind == CheckedPointerKind::Unchecked &&
         rhkind == CheckedPointerKind::Unchecked) {
-      if (RHSType->getPointeeType().isCheckableQualified()) {
-        // Again, should we allow or disallow this?
-        return Sema::Incompatible;
-      }
-
       Expr *RHSExpr = RHS.get();
       if (RHSExpr->isAddressOf() && addrOfExprRetMMSafePtr(RHSExpr)) {
         // Check if the RHS is an addr-of expression that returns

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -7991,6 +7991,47 @@ static bool addrOfExprRetMMSafePtr(Expr *UOExpr) {
   }
 }
 
+//
+// Checked C
+// This is a helper function that checks if an Expr is a pointer arithmetic
+// expression on a local or global constant array.
+//
+// Question: Should we support dynamic local arrays?
+//
+// FIXME? Although the current implementation works for the programs we have
+// seen, it looks suspicious.
+//
+static bool isPointerArithOnArray(Expr *E) {
+  E = E->IgnoreParenCasts();
+  const Type *T = E->getType().getTypePtr();
+
+  if (isa<DeclRefExpr>(E)) {
+    // Should be the case of just a local array, which is equal to the
+    // name of the array plus offset 0.
+    return T->getTypeClass() == Type::ConstantArray;
+  } else if (isa<BinaryOperator>(E)) {
+    while (true) {
+      // An binary expression can be arbitrarily long, e.g., a + b + c + ....
+      Expr *LHS = cast<BinaryOperator>(E)->getLHS()->IgnoreParenCasts();
+      Expr *RHS = cast<BinaryOperator>(E)->getRHS()->IgnoreParenCasts();
+      if(LHS->getType()->getTypeClass() == Type::ConstantArray ||
+         RHS->getType()->getTypeClass() == Type::ConstantArray) {
+        return true;
+      }
+
+      if (isa<BinaryOperator>(LHS)) {
+        E = LHS;
+      } else if (isa<BinaryOperator>(RHS)) {
+        E = RHS;
+      } else {
+        return false;
+      }
+    }
+  }
+
+  return false;
+}
+
 // checkPointerTypesForAssignment - This is a very tricky routine (despite
 // being closely modeled after the C99 spec:-). The odd characteristic of this
 // routine is it effectively iqnores the qualifiers on the top level pointee.
@@ -8086,8 +8127,10 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, ExprResult &RHS) {
   // Checked C
   // Check if this is assigning an unchecked pointer to an MMSafe pointer.
   // We disallow assigning a raw C pointer to an MMSafe pointer unless
-  // this pointer is constructed by getting the address of a memory object
-  // pointed by an MMSafe pointer.
+  // the raw pointer is
+  //    1. constructed from getting the address of a memory object pointed
+  //    by an MMSafe pointer.
+  //    2. an address of an address-taken stack or global object.
   //
   // Another implementation choice is to do the check earlier in
   // Sema::CheckSingleAssignmentConstraints(). In that case we do not need
@@ -8096,10 +8139,8 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, ExprResult &RHS) {
   if (rhkind == CheckedPointerKind::Unchecked &&
       (lhkind == CheckedPointerKind::MMPtr ||
        lhkind == CheckedPointerKind::MMArray)) {
-
-    // Check if the RHS is a ternary expression (c? a : b) and if any
-    // any of its results returns an mmsafe pointer.
     Expr *RHSExpr = RHS.get();
+
     if (RHSExpr->isAddressOf()) {
       // Check if the RHS is an addr-of expression and if it returns
       // an mmsafe pointer.
@@ -8122,6 +8163,12 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, ExprResult &RHS) {
         } else {
           return Sema::Incompatible;
         }
+    } else {
+      if (isPointerArithOnArray(RHSExpr) &&
+          lhkind == CheckedPointerKind::MMArray) {
+        // Check if this is an expression of an arithmetic expr on an array.
+        return Sema::Compatible;
+      }
     }
 
 #if 0


### PR DESCRIPTION
Before we required programmers to manually add the `_checkable` qualifier to local or global variables whose addresses are taken and passed to `mmsafe` pointers. Now we implemented the support for directly getting the address of a local or global variable and assigning it to an `mmsafe` pointer without the need to use the `_checkable` qualifier.

TODO: Clean `_checkable` related code. Currently they conflict with the code in this merge.